### PR TITLE
fix: remove at risk table from foreman overview page

### DIFF
--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -24,7 +24,6 @@ import { ActionCard } from "./action-card";
 import { AtRiskPopup } from "./exposure-level-popup";
 import { PieChartCard } from "./pie-chart-card";
 import { StatCard } from "./stat-card";
-import { AtRiskTable } from "./workers-at-risk-table";
 
 export default function ForemanOverview() {
 	const { t } = useTranslation();
@@ -204,7 +203,6 @@ export default function ForemanOverview() {
 							/>
 						</div>
 					</div>
-					<AtRiskTable users={subordinates ?? []} />
 
 					{sensor ? (
 						<UserStatusChart


### PR DESCRIPTION
This shouldn't be visible in the foreman overview page.

Closes HLTH-78