### PR TITLE
fix: undefined sensor in sensor detail pages

### DIFF
--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -111,7 +111,8 @@
     "warning": "En eksponeringsgrense var nær å bli brutt",
     "danger": "Eksponeringsgrense ble brutt",
     "openDaily": "Se detaljer for informasjon om eksponeringstype",
-    "eventTitle": "{{day}}, fra {{start}} til {{end}}"
+    "eventTitle": "{{day}}, fra {{start}} til {{end}}",
+    "notifTitle": "Notifikasjon mottatt {{date}}"
   },
   "profile": {
     "title": "Profil",


### PR DESCRIPTION
Fix the sensor type being undefined.
Before:
<img width="720" height="194" alt="image" src="https://github.com/user-attachments/assets/128fdc6a-4439-41b7-9241-c25c240cbcb1" />
After:
<img width="598" height="176" alt="image" src="https://github.com/user-attachments/assets/4a6d2337-549f-4d73-8c73-43d1ee7ef4ce" />
