### PR TITLE
feat: create live operator page scaffold

### DIFF
--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -2,6 +2,7 @@
   "title": "HealthTech | Operator Exposure Dashboard",
   "description": "Monitor and manage exposure to dust, vibration, and noise.",
   "layout": {
+    "live": "Live",
     "overview": "Overview",
     "home": "Home",
     "team": "Team",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -2,6 +2,7 @@
   "title": "HealthTech | Operatør Eksponeringsdashboard",
   "description": "Overvåk og administrer eksponering for støv, vibrasjon og støy.",
   "layout": {
+    "live": "Live",
     "overview": "Oversikt",
     "home": "Hjem",
     "team": "Team",

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -14,6 +14,7 @@ export default [
 			route("/operator/noise", "routes/operator/sensors/noise.tsx"),
 			route("/operator/", "routes/operator/home.tsx"),
 		]),
+		route("/operator/live", "routes/operator/live.tsx"),
 		route("/foreman/team", "routes/foreman/team.tsx"),
 	]),
 	route("/register", "routes/register.tsx"),

--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -96,6 +96,7 @@ function getLinks(
 
 		case "operator": {
 			return [
+				{ to: href("/operator/live"), label: t(($) => $.layout.live) },
 				{ to: href("/operator"), label: t(($) => $.layout.overview) },
 				{ to: href("/operator/dust"), label: t(($) => $.dust) },
 				{ to: href("/operator/noise"), label: t(($) => $.noise) },

--- a/frontend/app/routes/operator/live.tsx
+++ b/frontend/app/routes/operator/live.tsx
@@ -1,0 +1,13 @@
+import { DailyNotes } from "@/components/daily-notes";
+
+export default function OperatorLiveView() {
+	return (
+		<div className="flex w-full flex-col-reverse gap-4 md:flex-row">
+			<div className="flex w-1/5 shrink-0 flex-col gap-4">
+				<DailyNotes />
+			</div>
+
+			<div className="flex w-full min-w-0 flex-col gap-4"></div>
+		</div>
+	);
+}


### PR DESCRIPTION
Making this because the issue of creating the live operator page is divided across multiple people, so that we have somewhere to start