### PR TITLE
feat: only show hours in the week view where we have data in

### DIFF
--- a/frontend/app/routes/operator/sensors/dust.tsx
+++ b/frontend/app/routes/operator/sensors/dust.tsx
@@ -101,7 +101,7 @@ export default function Dust() {
 				) : view === "month" ? (
 					<CalendarWidget selectedDay={date} data={calendarData} />
 				) : view === "week" ? (
-					<WeekWidget dayStartHour={minHour} dayEndHour={(maxHour ?? 23) + 1} data={calendarData} />
+					<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
 				) : !data || data.length === 0 ? (
 					<Card className="flex h-24 w-full items-center">
 						<CardTitle>

--- a/frontend/app/routes/operator/sensors/noise.tsx
+++ b/frontend/app/routes/operator/sensors/noise.tsx
@@ -138,7 +138,7 @@ export default function Noise() {
 					</AggregationTabs>
 				) : view === "week" ? (
 					<AggregationTabs aggregation={aggregation} setAggregation={setAggregation}>
-						<WeekWidget dayStartHour={minHour} dayEndHour={(maxHour ?? 23) + 1} data={calendarData} />
+						<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
 					</AggregationTabs>
 				) : !data || data.length === 0 ? (
 					<Card className="flex h-24 w-full items-center">

--- a/frontend/app/routes/operator/sensors/vibration.tsx
+++ b/frontend/app/routes/operator/sensors/vibration.tsx
@@ -102,7 +102,7 @@ export default function Vibration() {
 				) : view === "month" ? (
 					<CalendarWidget selectedDay={date} data={calendarData} />
 				) : view === "week" ? (
-					<WeekWidget dayStartHour={minHour} dayEndHour={(maxHour ?? 23) + 1} data={calendarData} />
+					<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
 				) : !data || data.length === 0 ? (
 					<Card className="flex h-24 w-full items-center">
 						<CardTitle>


### PR DESCRIPTION
<img width="1025" height="876" alt="image" src="https://github.com/user-attachments/assets/d848408a-0852-4717-bdb7-a3a4fdc55a7c" />
Vibration and dust weekly views.

<img width="1979" height="902" alt="image" src="https://github.com/user-attachments/assets/f4d35e5c-8a7a-4862-a38d-664d32616714" />
Noise weekly view.

 The bottom empty rows are for each view are extra padding from before.

**This issue should be merged after** #226 