### PR TITLE
fix: make sure LineChart graph color always corresponds to danger level

### DIFF
--- a/frontend/app/components/line-chart.tsx
+++ b/frontend/app/components/line-chart.tsx
@@ -86,13 +86,9 @@ export function ChartLineDefault({
 	const dataMin = getValue(minData);
 	const dataMax = getValue(maxData);
 
-	console.log(dangerThreshold, warning, dataMax, dataMin)
-
 	const isAllDanger = dangerThreshold <= dataMin;
-	const isAllWarning = dangerThreshold >= dataMax && warning <= dataMin
+	const isAllWarning = dangerThreshold >= dataMax && warning <= dataMin;
 	const isAllSafe = warning >= dataMax;
-
-	console.log(isAllWarning)
 
 	return (
 		<Card className="w-full">


### PR DESCRIPTION
Before:

<img width="1580" height="235" alt="image" src="https://github.com/user-attachments/assets/5e37bf25-3f7d-45dc-8d90-81cb6a93826e" />

Now:

<img width="1867" height="524" alt="image" src="https://github.com/user-attachments/assets/9696eb6d-7ca2-48a7-a9b0-807e7b14fd04" />
