### PR TITLE
feat: add tab to show data for 8 hours in live view

### DIFF
--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -67,9 +67,10 @@
     "timeRange": {
       "label": "Time range",
       "options": {
-        "thirtyMinutes": "30 minutes",
+        "thirtyMinutes": "30 min",
         "oneHour": "1 hour",
-        "threeHours": "3 hours"
+        "threeHours": "3 hours",
+        "eightHours": "8 hours"
       }
     },
     "chart": {

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -67,9 +67,10 @@
     "timeRange": {
       "label": "Tidsrom",
       "options": {
-        "thirtyMinutes": "30 minutter",
+        "thirtyMinutes": "30 min",
         "oneHour": "1 time",
-        "threeHours": "3 timer"
+        "threeHours": "3 timer",
+        "eightHours": "8 timer"
       }
     },
     "chart": {

--- a/frontend/app/routes/operator/live.tsx
+++ b/frontend/app/routes/operator/live.tsx
@@ -20,13 +20,14 @@ import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-type TimeRangeOption = "30" | "60" | "180";
-const parseTimeRange = parseAsStringLiteral(["30", "60", "180"]);
+type TimeRangeOption = "30" | "60" | "180" | "480";
+const parseTimeRange = parseAsStringLiteral(["30", "60", "180", "480"]);
 
 const TIME_RANGE_MINUTES: Record<TimeRangeOption, number> = {
 	"30": 30,
 	"60": 60,
 	"180": 180,
+	"480": 480,
 };
 
 export default function OperatorLiveView() {
@@ -236,14 +237,33 @@ export default function OperatorLiveView() {
 							setTimeRange(value);
 						}}
 					>
-						<ToggleGroupItem value="30" aria-label={t(($) => $.live.timeRange.options.thirtyMinutes)}>
+						<ToggleGroupItem
+							className="text-xs"
+							value="30"
+							aria-label={t(($) => $.live.timeRange.options.thirtyMinutes)}
+						>
 							<p>{t(($) => $.live.timeRange.options.thirtyMinutes)}</p>
 						</ToggleGroupItem>
-						<ToggleGroupItem value="60" aria-label={t(($) => $.live.timeRange.options.oneHour)}>
+						<ToggleGroupItem
+							className="text-xs"
+							value="60"
+							aria-label={t(($) => $.live.timeRange.options.oneHour)}
+						>
 							<p>{t(($) => $.live.timeRange.options.oneHour)}</p>
 						</ToggleGroupItem>
-						<ToggleGroupItem value="180" aria-label={t(($) => $.live.timeRange.options.threeHours)}>
+						<ToggleGroupItem
+							className="text-xs"
+							value="180"
+							aria-label={t(($) => $.live.timeRange.options.threeHours)}
+						>
 							<p>{t(($) => $.live.timeRange.options.threeHours)}</p>
+						</ToggleGroupItem>
+						<ToggleGroupItem
+							className="text-xs"
+							value="480"
+							aria-label={t(($) => $.live.timeRange.options.eightHours)}
+						>
+							<p>{t(($) => $.live.timeRange.options.eightHours)}</p>
 						</ToggleGroupItem>
 					</ToggleGroup>
 				</Card>


### PR DESCRIPTION
<img width="2541" height="1260" alt="image" src="https://github.com/user-attachments/assets/0849174d-6096-4be4-a550-4341d3569988" />
