### PR TITLE
feat(frontend): improve colorblind accessibility

### DIFF
--- a/frontend/app/components/daily-bar-chart.tsx
+++ b/frontend/app/components/daily-bar-chart.tsx
@@ -8,6 +8,7 @@ import { setHours, startOfDay } from "date-fns";
 import { Fragment, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, type To } from "react-router";
+import { DangerLevelDots } from "./danger-level-dots.js";
 import { SensorIcon } from "./sensor-icon.js";
 
 const CELL_SIZE = 10;
@@ -160,9 +161,15 @@ export function DailyBarChart({ data, startHour = 0, endHour = 23, headerRight, 
 												key={`${sensor}-${localHour}`}
 												to={linkTarget}
 												title={`${timeLabel} - ${dangerLevel}`}
-												className={className}
+												className="relative"
 												aria-label={`View ${sensor} data for ${timeLabel}`}
-											/>
+											>
+												<div className={className} />
+												<DangerLevelDots
+													dangerLevel={dangerLevel ?? null}
+													className="absolute right-1 bottom-1"
+												/>
+											</Link>
 										);
 									})}
 								</Fragment>

--- a/frontend/app/components/danger-level-dots.tsx
+++ b/frontend/app/components/danger-level-dots.tsx
@@ -1,0 +1,36 @@
+import { DANGER_LEVEL_SEVERITY, type DangerLevel } from "@/lib/danger-levels.js";
+import { cn } from "@/lib/utils.js";
+
+interface DangerLevelDotsProps {
+	dangerLevel: DangerLevel | null;
+	horizontal?: boolean;
+	className?: string;
+}
+
+export function DangerLevelDots({ dangerLevel, className, horizontal = false }: DangerLevelDotsProps) {
+	if (dangerLevel === null) {
+		return null;
+	}
+
+	const dotCount = DANGER_LEVEL_SEVERITY[dangerLevel] + 1;
+	const dots = Array.from({ length: dotCount }, () => (
+		<div
+			key={`dot-${dangerLevel}`}
+			className="size-1 rounded-full"
+			style={{ backgroundColor: `var(--${dangerLevel}-text)` }}
+		/>
+	));
+
+	if (dotCount < 3) {
+		return (
+			<div className={cn("flex", horizontal ? "flex-row gap-0.5" : "flex-col gap-0.5", className)}>{dots}</div>
+		);
+	}
+
+	return (
+		<div className={cn("grid grid-cols-2 justify-items-center gap-0.5", className)}>
+			<div className="col-span-2">{dots[0]}</div>
+			{dots.slice(1)}
+		</div>
+	);
+}

--- a/frontend/app/components/line-chart.tsx
+++ b/frontend/app/components/line-chart.tsx
@@ -334,26 +334,33 @@ const Dot = ({ cx, cy, value, warning, danger, isPeak }: DotProps & { isPeak?: b
 	return <circle cx={cx} cy={cy} r={6} fill={fillColor} />;
 };
 
-export function ThresholdLine({
-	y,
-	dangerLevel,
-	label,
-	hideLineLabel,
-}: {
-	y: number;
+interface ThresholdLineProps {
 	dangerLevel: DangerLevel;
 	label?: string;
 	hideLineLabel?: boolean;
-}) {
+}
+
+export function ThresholdLine({
+	dangerLevel,
+	label,
+	hideLineLabel,
+	...props
+}: ThresholdLineProps & ({ y: number } | { x: number })) {
 	const { t } = useTranslation();
 	const color = `var(--${DangerLevels[dangerLevel].color})`;
 	const lineLabel = hideLineLabel ? undefined : (label ?? t(($) => $.lineChart[dangerLevel]));
 
+	const y = "y" in props ? props.y : undefined;
+	const x = "x" in props ? props.x : undefined;
+
+	const strokeDasharray = dangerLevel === "danger" ? "8 4" : "4 4";
+
 	return (
 		<ReferenceLine
 			y={y}
+			x={x}
 			stroke={color}
-			strokeDasharray="4 4"
+			strokeDasharray={strokeDasharray}
 			label={{
 				value: lineLabel,
 				position: "left",

--- a/frontend/app/components/sensor-icon.tsx
+++ b/frontend/app/components/sensor-icon.tsx
@@ -5,6 +5,7 @@ import type { Sensor } from "@/lib/sensors.js";
 import { cn } from "@/lib/utils.js";
 import { ShieldAlertIcon } from "lucide-react";
 import type { ComponentType } from "react";
+import { DangerLevelDots } from "./danger-level-dots.js";
 import { NoiseIcon } from "./icons/noise-icon";
 
 export type IconProps = Omit<React.SVGProps<SVGSVGElement>, "width" | "height" | "strokeWidth"> & {
@@ -59,10 +60,15 @@ export const SensorIcon = ({ type, size, dangerLevel, className, iconClassName, 
 		: defaultIconContainerClass;
 
 	return (
-		<Component className={cn("h-fit w-fit rounded-full border", dangerLevelIconClasses, className)}>
+		<Component className={cn("relative h-fit w-fit rounded-full border", dangerLevelIconClasses, className)}>
 			<Icon
 				className={cn(iconSizeClass[resolvedIconSize], inline && "inline-block", iconClassName)}
 				title={title}
+			/>
+			<DangerLevelDots
+				dangerLevel={dangerLevel ?? null}
+				horizontal={true}
+				className="absolute -right-0.25 -bottom-0.25"
 			/>
 		</Component>
 	);

--- a/frontend/app/components/users-status-chart.tsx
+++ b/frontend/app/components/users-status-chart.tsx
@@ -7,7 +7,8 @@ import type { UserWithStatusDto } from "@/lib/dto";
 import { getThreshold } from "@/lib/thresholds";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import { Bar, BarChart, type BarProps, CartesianGrid, ReferenceLine, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, type BarProps, CartesianGrid, XAxis, YAxis } from "recharts";
+import { ThresholdLine } from "./line-chart.js";
 
 interface Props {
 	users: Array<UserWithStatusDto>;
@@ -139,32 +140,8 @@ export function UserStatusChart({ users, sensor, userOnClick }: Props) {
 								fill: "var(--color-muted-foreground)",
 							}}
 						/>
-						<ReferenceLine
-							x={warningThresholdLine}
-							stroke="var(--warning)"
-							strokeDasharray="6 4"
-							strokeWidth={2}
-							label={{
-								value: t(($) => $.dangerLevels.warning),
-								position: "insideTopRight",
-								dy: -16,
-								fill: "var(--warning)",
-								className: "text-base",
-							}}
-						/>
-						<ReferenceLine
-							x={dangerThresholdLine}
-							stroke="var(--danger)"
-							strokeDasharray="6 4"
-							strokeWidth={2}
-							label={{
-								value: t(($) => $.dangerLevels.danger),
-								position: "insideTopLeft",
-								dy: -16,
-								fill: "var(--danger)",
-								className: "text-base",
-							}}
-						/>
+						<ThresholdLine x={warningThresholdLine} dangerLevel="warning" />
+						<ThresholdLine x={dangerThresholdLine} dangerLevel="danger" />
 						<ChartTooltip
 							cursor={false}
 							content={({ active, payload, label }) => {

--- a/frontend/app/components/users-status-pie-chart.tsx
+++ b/frontend/app/components/users-status-pie-chart.tsx
@@ -1,5 +1,9 @@
 import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
-import { Pie, PieChart, type PieSectorShapeProps, Sector } from "recharts";
+import { DangerLevelSchema } from "@/lib/danger-levels.js";
+import { Pie, PieChart, type PieLabelRenderProps, type PieSectorShapeProps, Sector } from "recharts";
+import { DangerLevelDots } from "./danger-level-dots.js";
+
+const RADIAN = Math.PI / 180;
 
 const pieShape = (props: PieSectorShapeProps) => {
 	const colorMap: Record<string, string> = {
@@ -29,6 +33,7 @@ export function UserStatusPieChart({ safe, warning, danger }: UserStatusData) {
 					shape={pieShape}
 					innerRadius="60%"
 					outerRadius="100%"
+					label={CustomLabel}
 				/>
 				<ChartTooltip
 					content={({ active, payload }) => {
@@ -53,3 +58,27 @@ export function UserStatusPieChart({ safe, warning, danger }: UserStatusData) {
 		</ChartContainer>
 	);
 }
+
+const CustomLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name }: PieLabelRenderProps) => {
+	// Don't render a label if the pie takes up 0% of the chart
+	if (percent === 0) {
+		return null;
+	}
+
+	const sizePx = 10;
+
+	const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+	const x = Number(cx) + radius * Math.cos(-(midAngle ?? 0) * RADIAN);
+	const y = Number(cy) + radius * Math.sin(-(midAngle ?? 0) * RADIAN);
+
+	const dangerLevelParseResult = DangerLevelSchema.safeParse(name?.toLowerCase());
+	const dangerLevel = dangerLevelParseResult.success ? dangerLevelParseResult.data : null;
+
+	return (
+		<g transform={`translate(${x},${y})`} className="relative">
+			<foreignObject x={-sizePx / 2} y={-sizePx / 2} width={sizePx} height={sizePx}>
+				<DangerLevelDots dangerLevel={dangerLevel} />
+			</foreignObject>
+		</g>
+	);
+};

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/correctness/noNestedComponentDefinitions: CustomDay is intentionally defined inside CalendarView for prop access. */
 
+import { DangerLevelDots } from "@/components/danger-level-dots.js";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Card } from "@/components/ui/card";
@@ -166,16 +167,15 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 	}
 
 	return (
-		<button
-			type="button"
-			disabled={disabled}
-			className={cn(
-				"h-full w-full rounded-lg",
-				!disabled && "cursor-pointer hover:brightness-85",
-				bgClassname,
-				className,
-			)}
-			{...buttonProps}
-		/>
+		<button type="button" disabled={disabled} className={cn("relative h-full w-full rounded-lg")} {...buttonProps}>
+			<div
+				className={cn(
+					"h-full w-full rounded-lg",
+					!disabled && "cursor-pointer hover:brightness-85",
+					bgClassname,
+				)}
+			/>
+			<DangerLevelDots dangerLevel={dangerLevel ?? null} className="absolute right-1 bottom-1" />
+		</button>
 	);
 }

--- a/frontend/app/features/week-widget/week-widget.tsx
+++ b/frontend/app/features/week-widget/week-widget.tsx
@@ -1,3 +1,4 @@
+import { DangerLevelDots } from "@/components/danger-level-dots.js";
 import { useDate } from "@/features/date-picker/use-date";
 import { WeeklyPopup } from "@/features/popups/weekly-popup";
 import { useFormatDate } from "@/hooks/use-format-date.js";
@@ -279,7 +280,13 @@ function Cell({ isFirstRow, isLastRow, timeBuckets, style, onSegmentClick }: Cel
 							bottom: `calc(${bottomPercent}% + 1px)`,
 						}}
 						onClick={() => onSegmentClick(timeBucket)}
-					/>
+					>
+						<div className={cn(rounding)} style={{ backgroundColor: dangerColor }} />
+						<DangerLevelDots
+							dangerLevel={timeBucket.dangerLevel ?? null}
+							className="absolute right-1 bottom-1"
+						/>
+					</button>
 				);
 			})}
 		</div>


### PR DESCRIPTION
Adds dots to the plain, colored rectangles so they are able to be differentiated without color.

<img width="641" height="539" alt="image" src="https://github.com/user-attachments/assets/410160b0-0dd5-43a2-96c3-ce2d4db64957" />
<img width="2557" height="786" alt="image" src="https://github.com/user-attachments/assets/61be28c5-b713-4ced-9833-83e09abfa23b" />
<img width="2557" height="786" alt="image" src="https://github.com/user-attachments/assets/c9940f41-5ba0-4907-af28-e834e47bc968" />
<img width="1719" height="651" alt="image" src="https://github.com/user-attachments/assets/f943bceb-cdf7-498d-8941-010c963112fa" />
<img width="781" height="649" alt="image" src="https://github.com/user-attachments/assets/4f0c9abb-ad09-491f-9945-747ba855b493" />
<img width="1456" height="762" alt="image" src="https://github.com/user-attachments/assets/5a2a4126-8862-40aa-85f2-a106912864ab" />
<img width="356" height="458" alt="image" src="https://github.com/user-attachments/assets/170c8608-9b80-4206-b3ff-ce386e2e6d7a" />
