### PR TITLE
feat(Foreman): add toggle for week granularity

### DIFF
--- a/backend/src/Services/UserStatusService.cs
+++ b/backend/src/Services/UserStatusService.cs
@@ -56,7 +56,7 @@ public class UserStatusService(AppDbContext _context, SignedInUserContext _signe
 		var dustRows = await _context
 			.Database.SqlQuery<UserAggRow>(
 				$"""
-				SELECT "user_id" as "UserId", MAX(max_dust_Pm1_twa) as Value, null as MaxValue
+				SELECT "user_id" as "UserId", AVG(max_dust_Pm1_twa) as Value, null as MaxValue
 				FROM dust_data_minutely
 				WHERE bucket between {startTime} and {endTime}
 				  AND "user_id" = ANY({ids})

--- a/frontend/app/components/users-status-chart.tsx
+++ b/frontend/app/components/users-status-chart.tsx
@@ -186,9 +186,7 @@ export function UserStatusChart({ users, sensor, userOnClick, isWeekly }: Props)
 										<div className="font-medium">{label}</div>
 										<div className="flex items-center justify-between gap-2">
 											<span className="text-muted-foreground">
-												{sensor === "dust" && isWeekly
-													? t(($) => $.measurement.dustWeek)
-													: t(($) => $.measurement.average)}
+												{t(($) => $.measurement.average)}
 											</span>
 											<span className="font-medium font-mono text-foreground tabular-nums">
 												{`${avg}%`}

--- a/frontend/app/components/users-status-chart.tsx
+++ b/frontend/app/components/users-status-chart.tsx
@@ -13,9 +13,10 @@ interface Props {
 	users: Array<UserWithStatusDto>;
 	sensor: Sensor;
 	userOnClick?: (userId: string) => void;
+	isWeekly?: boolean;
 }
 
-export function UserStatusChart({ users, sensor, userOnClick }: Props) {
+export function UserStatusChart({ users, sensor, userOnClick, isWeekly }: Props) {
 	const [t] = useTranslation();
 	const threshold = getThreshold(sensor);
 	const getPercent = (value: number) => Math.round((value / threshold.danger) * 100);
@@ -33,7 +34,12 @@ export function UserStatusChart({ users, sensor, userOnClick }: Props) {
 			return [];
 		}
 
-		const percent = getPercent(sensorStatus.value);
+		const days = isWeekly ? 7 : 1;
+
+		// Vibration should show average value in graph
+		const normalizedValue = sensor === "vibration" ? sensorStatus.value / days : sensorStatus.value;
+
+		const percent = getPercent(normalizedValue);
 		// Only show peak if it's above the current value
 		const peakPercent =
 			sensorStatus.peakValue && sensorStatus.peakValue > sensorStatus.value
@@ -180,7 +186,9 @@ export function UserStatusChart({ users, sensor, userOnClick }: Props) {
 										<div className="font-medium">{label}</div>
 										<div className="flex items-center justify-between gap-2">
 											<span className="text-muted-foreground">
-												{t(($) => $.measurement.average)}
+												{sensor === "dust" && isWeekly
+													? t(($) => $.measurement.dustWeek)
+													: t(($) => $.measurement.average)}
 											</span>
 											<span className="font-medium font-mono text-foreground tabular-nums">
 												{`${avg}%`}

--- a/frontend/app/features/attention-card/attention-card.tsx
+++ b/frontend/app/features/attention-card/attention-card.tsx
@@ -1,6 +1,7 @@
 import { ExposureRiskCard } from "@/components/exposure-level-card";
 import { Card, CardContent, CardHeader } from "@/components/ui/card.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { AtRiskPopup } from "@/features/attention-card/exposure-level-popup.js";
 import { StatCard } from "@/features/attention-card/stat-card";
 import { TIMEZONE } from "@/i18n/locale";
@@ -13,12 +14,15 @@ import { isSameDay } from "date-fns";
 import { parseAsString, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { DayViewIcon, WeekViewIcon } from "../views/views";
 
 interface AttentionCardProps {
 	subordinates: Array<UserWithStatusDto>;
 	isSubordinatesLoading?: boolean;
 	thresholdSummary?: ThresholdSummary;
 	isThresholdSummaryLoading?: boolean;
+	isWeekly?: boolean;
+	onToggleWeekly?: (value: boolean) => void;
 }
 
 export const AttentionCard = ({
@@ -26,6 +30,8 @@ export const AttentionCard = ({
 	isSubordinatesLoading,
 	thresholdSummary,
 	isThresholdSummaryLoading,
+	isWeekly,
+	onToggleWeekly,
 }: AttentionCardProps) => {
 	const { t } = useTranslation();
 	const [sensor] = useQueryState("sensor", parseAsSensor);
@@ -66,10 +72,11 @@ export const AttentionCard = ({
 	}, [thresholdSummary, subordinates, sensor]);
 
 	const selectedSensorKey = sensor ?? "total";
-	const showActionCard = date ? isSameDay(date, now(), { in: TIMEZONE }) : false;
+	const showActionCard = !isWeekly && date ? isSameDay(date, now(), { in: TIMEZONE }) : false;
 
 	const dangerLevelColor = highestDangerLevel === null ? null : `text-${mapDangerLevelToColor(highestDangerLevel)}`;
 
+	// Daily granularity text
 	const attentionHeaderText =
 		highestDangerLevel === null ? null : t(($) => $.foremanDashboard.actionCard[highestDangerLevel]);
 
@@ -78,6 +85,16 @@ export const AttentionCard = ({
 
 	const approachingThresholdText =
 		highestDangerLevel === "warning" ? t(($) => $.foremanDashboard.actionCard.approachingThresholdText) : null;
+
+	// Weekly granularity text
+	const weeklyHeaderText =
+		highestDangerLevel === null ? null : t(($) => $.foremanDashboard.actionCard[highestDangerLevel]);
+
+	const weekCriticalExposureText =
+		highestDangerLevel === "danger" ? t(($) => $.foremanDashboard.actionCard.weekCriticalExposureText) : null;
+
+	const weekApproachingThresholdText =
+		highestDangerLevel === "warning" ? t(($) => $.foremanDashboard.actionCard.weekApproachingExposureText) : null;
 
 	if (isThresholdSummaryLoading || thresholdSummary === undefined || highestDangerLevel === null) {
 		return (
@@ -88,13 +105,40 @@ export const AttentionCard = ({
 		);
 	}
 
-	const actionCardHeader = showActionCard && (
-		<CardHeader>
+	const actionCardHeader = (
+		<CardHeader className="flex flex-row items-center justify-between">
 			{isSubordinatesLoading ? (
 				<Skeleton className="h-8 w-[50%] rounded-full bg-zinc-100 dark:bg-accent" />
 			) : (
-				<h2 className={cn("font-bold text-2xl", dangerLevelColor)}>{attentionHeaderText}</h2>
+				<h2 className={cn("font-bold text-2xl", dangerLevelColor)}>
+					{isWeekly ? weeklyHeaderText : attentionHeaderText}
+				</h2>
 			)}
+
+			<ToggleGroup
+				type="single"
+				value={isWeekly ? "week" : "day"}
+				variant="outline"
+				className="grid w-[140px] grid-cols-2"
+				onValueChange={(value) => {
+					if (!value) return;
+					onToggleWeekly?.(value === "week");
+				}}
+			>
+				<ToggleGroupItem value="day">
+					<div className="flex items-center gap-2">
+						<DayViewIcon className="size-4" />
+						<p className="text-sm">{t(($) => $.foremanDashboard.actionCard.day)}</p>
+					</div>
+				</ToggleGroupItem>
+
+				<ToggleGroupItem value="week">
+					<div className="flex items-center gap-2">
+						<WeekViewIcon className="size-4" />
+						<p className="text-sm">{t(($) => $.foremanDashboard.actionCard.week)}</p>
+					</div>
+				</ToggleGroupItem>
+			</ToggleGroup>
 		</CardHeader>
 	);
 
@@ -104,14 +148,19 @@ export const AttentionCard = ({
 				{actionCardHeader}
 
 				<CardContent className="gap-2">
-					{showActionCard ? (
+					{isWeekly ? (
 						<>
-							{" "}
-							<p>{criticalExposureText}</p> <p>{approachingThresholdText}</p>{" "}
+							{weekCriticalExposureText && <p>{weekCriticalExposureText}</p>}
+							{weekApproachingThresholdText && <p>{weekApproachingThresholdText}</p>}
+						</>
+					) : showActionCard ? (
+						<>
+							{criticalExposureText && <p>{criticalExposureText}</p>}
+							{approachingThresholdText && <p>{approachingThresholdText}</p>}
 						</>
 					) : (
 						<p>{t(($) => $.foremanDashboard.actionCard.oldData)}</p>
-					)}{" "}
+					)}
 					<div className="mt-5 grid items-stretch gap-6 md:grid-cols-2 lg:col-span-3 lg:grid-cols-3">
 						{!sensor && (
 							<>

--- a/frontend/app/features/attention-card/attention-card.tsx
+++ b/frontend/app/features/attention-card/attention-card.tsx
@@ -72,26 +72,15 @@ export const AttentionCard = ({
 	const showActionCard = !isWeekly && date ? isSameDay(date, now(), { in: TIMEZONE }) : false;
 
 	const dangerLevelColor = highestDangerLevel === null ? null : `text-${mapDangerLevelToColor(highestDangerLevel)}`;
+	const viewKey = isWeekly ? "weekView" : "dayView";
 
-	// Daily granularity text
 	const attentionHeaderText =
 		highestDangerLevel === null ? null : t(($) => $.foremanDashboard.actionCard[highestDangerLevel]);
 
-	const criticalExposureText =
-		highestDangerLevel === "danger" ? t(($) => $.foremanDashboard.actionCard.criticalExposureText) : null;
-
-	const approachingThresholdText =
-		highestDangerLevel === "warning" ? t(($) => $.foremanDashboard.actionCard.approachingThresholdText) : null;
-
-	// Weekly granularity text
-	const weeklyHeaderText =
-		highestDangerLevel === null ? null : t(($) => $.foremanDashboard.actionCard[highestDangerLevel]);
-
-	const weekCriticalExposureText =
-		highestDangerLevel === "danger" ? t(($) => $.foremanDashboard.actionCard.weekCriticalExposureText) : null;
-
-	const weekApproachingThresholdText =
-		highestDangerLevel === "warning" ? t(($) => $.foremanDashboard.actionCard.weekApproachingExposureText) : null;
+	const detailText =
+		highestDangerLevel === "danger" || highestDangerLevel === "warning"
+			? t(($) => $.foremanDashboard.actionCard[viewKey][highestDangerLevel])
+			: null;
 
 	if (isThresholdSummaryLoading || thresholdSummary === undefined || highestDangerLevel === null) {
 		return (
@@ -107,9 +96,7 @@ export const AttentionCard = ({
 			{isSubordinatesLoading ? (
 				<Skeleton className="h-8 w-[50%] rounded-full bg-zinc-100 dark:bg-accent" />
 			) : (
-				<h2 className={cn("font-bold text-2xl", dangerLevelColor)}>
-					{isWeekly ? weeklyHeaderText : attentionHeaderText}
-				</h2>
+				<h2 className={cn("font-bold text-2xl", dangerLevelColor)}>{attentionHeaderText}</h2>
 			)}
 		</CardHeader>
 	);
@@ -120,16 +107,8 @@ export const AttentionCard = ({
 				{actionCardHeader}
 
 				<CardContent className="gap-2">
-					{isWeekly ? (
-						<>
-							{weekCriticalExposureText && <p>{weekCriticalExposureText}</p>}
-							{weekApproachingThresholdText && <p>{weekApproachingThresholdText}</p>}
-						</>
-					) : showActionCard ? (
-						<>
-							{criticalExposureText && <p>{criticalExposureText}</p>}
-							{approachingThresholdText && <p>{approachingThresholdText}</p>}
-						</>
+					{showActionCard || isWeekly ? (
+						detailText && <p>{detailText}</p>
 					) : (
 						<p>{t(($) => $.foremanDashboard.actionCard.oldData)}</p>
 					)}

--- a/frontend/app/features/attention-card/attention-card.tsx
+++ b/frontend/app/features/attention-card/attention-card.tsx
@@ -1,7 +1,6 @@
 import { ExposureRiskCard } from "@/components/exposure-level-card";
 import { Card, CardContent, CardHeader } from "@/components/ui/card.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { AtRiskPopup } from "@/features/attention-card/exposure-level-popup.js";
 import { StatCard } from "@/features/attention-card/stat-card";
 import { TIMEZONE } from "@/i18n/locale";
@@ -14,7 +13,6 @@ import { isSameDay } from "date-fns";
 import { parseAsString, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { DayViewIcon, WeekViewIcon } from "../views/views";
 
 interface AttentionCardProps {
 	subordinates: Array<UserWithStatusDto>;
@@ -22,7 +20,6 @@ interface AttentionCardProps {
 	thresholdSummary?: ThresholdSummary;
 	isThresholdSummaryLoading?: boolean;
 	isWeekly?: boolean;
-	onToggleWeekly?: (value: boolean) => void;
 }
 
 export const AttentionCard = ({
@@ -31,7 +28,6 @@ export const AttentionCard = ({
 	thresholdSummary,
 	isThresholdSummaryLoading,
 	isWeekly,
-	onToggleWeekly,
 }: AttentionCardProps) => {
 	const { t } = useTranslation();
 	const [sensor] = useQueryState("sensor", parseAsSensor);
@@ -114,31 +110,6 @@ export const AttentionCard = ({
 					{isWeekly ? weeklyHeaderText : attentionHeaderText}
 				</h2>
 			)}
-
-			<ToggleGroup
-				type="single"
-				value={isWeekly ? "week" : "day"}
-				variant="outline"
-				className="grid w-[140px] grid-cols-2"
-				onValueChange={(value) => {
-					if (!value) return;
-					onToggleWeekly?.(value === "week");
-				}}
-			>
-				<ToggleGroupItem value="day">
-					<div className="flex items-center gap-2">
-						<DayViewIcon className="size-4" />
-						<p className="text-sm">{t(($) => $.foremanDashboard.actionCard.day)}</p>
-					</div>
-				</ToggleGroupItem>
-
-				<ToggleGroupItem value="week">
-					<div className="flex items-center gap-2">
-						<WeekViewIcon className="size-4" />
-						<p className="text-sm">{t(($) => $.foremanDashboard.actionCard.week)}</p>
-					</div>
-				</ToggleGroupItem>
-			</ToggleGroup>
 		</CardHeader>
 	);
 

--- a/frontend/app/features/views/view-picker.tsx
+++ b/frontend/app/features/views/view-picker.tsx
@@ -14,12 +14,14 @@ import { DayViewIcon, MonthViewIcon, WeekViewIcon } from "./views";
 interface ViewPickerProps {
 	withNavigationButtons?: boolean;
 	className?: string;
+	allowedViews?: Array<View>;
 }
 
-export function ViewPicker({ className, withNavigationButtons = false }: ViewPickerProps) {
+export function ViewPicker({ className, withNavigationButtons = false, allowedViews }: ViewPickerProps) {
 	const { view, setView } = useView();
 	const { date, navigate, setDate } = useDate();
 	const { t } = useTranslation();
+	const views = allowedViews ?? ["day", "week", "month"];
 
 	const isTodayDate = isToday(date, { in: TIMEZONE });
 
@@ -29,38 +31,48 @@ export function ViewPicker({ className, withNavigationButtons = false }: ViewPic
 
 	return (
 		<div className="flex flex-col gap-2">
-			<ToggleGroup
-				type="single"
-				value={view}
-				variant="outline"
-				className={cn("grid grid-cols-3", className)}
-				onValueChange={(value: View) => {
-					// Value is an empty string when clicking the already selected item, so we need this check to avoid
-					// deselecting.
-					if (value) {
-						setView(value);
-					}
-				}}
-			>
-				<ToggleGroupItem value="day" aria-label={t(($) => $.views.day)}>
-					<div className="flex items-center gap-2">
-						<DayViewIcon className="size-4" />
-						<p className="text-sm">{t(($) => $.views.day)}</p>
-					</div>
-				</ToggleGroupItem>
-				<ToggleGroupItem value="week" aria-label={t(($) => $.views.week)}>
-					<div className="flex items-center gap-2">
-						<WeekViewIcon className="size-4" />
-						<p className="text-sm">{t(($) => $.views.week)}</p>
-					</div>
-				</ToggleGroupItem>
-				<ToggleGroupItem value="month" aria-label={t(($) => $.views.month)}>
-					<div className="flex items-center gap-2">
-						<MonthViewIcon className="size-4" />
-						<p className="text-sm">{t(($) => $.views.month)}</p>
-					</div>
-				</ToggleGroupItem>
-			</ToggleGroup>
+			<div className="flex justify-center">
+				<ToggleGroup
+					type="single"
+					value={view}
+					variant="outline"
+					className={cn("inline-grid w-fit auto-cols-fr grid-flow-col", className)}
+					onValueChange={(value: View) => {
+						// Value is an empty string when clicking the already selected item, so we need this check to avoid
+						// deselecting.
+						if (value) {
+							setView(value);
+						}
+					}}
+				>
+					{views.includes("day") && (
+						<ToggleGroupItem value="day" aria-label={t(($) => $.views.day)}>
+							<div className="flex items-center gap-2">
+								<DayViewIcon className="size-4" />
+								<p className="text-sm">{t(($) => $.views.day)}</p>
+							</div>
+						</ToggleGroupItem>
+					)}
+
+					{views.includes("week") && (
+						<ToggleGroupItem value="week" aria-label={t(($) => $.views.week)}>
+							<div className="flex items-center gap-2">
+								<WeekViewIcon className="size-4" />
+								<p className="text-sm">{t(($) => $.views.week)}</p>
+							</div>
+						</ToggleGroupItem>
+					)}
+
+					{views.includes("month") && (
+						<ToggleGroupItem value="month" aria-label={t(($) => $.views.month)}>
+							<div className="flex items-center gap-2">
+								<MonthViewIcon className="size-4" />
+								<p className="text-sm">{t(($) => $.views.month)}</p>
+							</div>
+						</ToggleGroupItem>
+					)}
+				</ToggleGroup>
+			</div>
 
 			{withNavigationButtons && (
 				<div className="grid grid-cols-3 items-center gap-2">

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -50,7 +50,8 @@
   "measurement": {
     "peak": "Peak",
     "average": "Average",
-    "averageExposure": "Average exposure"
+    "averageExposure": "Average exposure",
+    "dustWeek": "Daily peak value"
   },
   "layout": {
     "live": "Live",
@@ -214,7 +215,11 @@
       "danger": "Attention may be required!",
       "criticalExposureText": "Operators above the exposure limit. Immediate follow-up recommended.",
       "approachingThresholdText": "Operators approaching the exposure limit. Consider preventive measures.",
-      "oldData": "You are viewing old data."
+      "weekCriticalExposureText": "Operators above the weekly exposure limit. Immediate follow-up recommended.",
+      "weekApproachingExposureText": "Operators approaching the weekly exposure limit. Consider preventive measures.",
+      "oldData": "You are viewing old data.",
+      "day": "Day",
+      "week": "Week"
     },
     "userStatusChart": {
       "xAxisLabel": "Percentage of exposure limit",

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -213,10 +213,14 @@
       "safe": "All good!",
       "warning": "Attention may be required!",
       "danger": "Attention may be required!",
-      "criticalExposureText": "Operators above the exposure limit. Immediate follow-up recommended.",
-      "approachingThresholdText": "Operators approaching the exposure limit. Consider preventive measures.",
-      "weekCriticalExposureText": "Operators above the weekly exposure limit. Immediate follow-up recommended.",
-      "weekApproachingExposureText": "Operators approaching the weekly exposure limit. Consider preventive measures.",
+      "dayView": {
+        "danger": "Operators above the exposure limit. Immediate follow-up recommended.",
+        "warning": "Operators approaching the exposure limit. Consider preventive measures."
+      },
+      "weekView": {
+        "danger": "Operators above the weekly exposure limit. Immediate follow-up recommended.",
+        "warning": "Operators approaching the weekly exposure limit. Consider preventive measures."
+      },
       "oldData": "You are viewing old data.",
       "day": "Day",
       "week": "Week"

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -50,8 +50,7 @@
   "measurement": {
     "peak": "Peak",
     "average": "Average",
-    "averageExposure": "Average exposure",
-    "dustWeek": "Daily peak value"
+    "averageExposure": "Average exposure"
   },
   "layout": {
     "live": "Live",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -50,8 +50,7 @@
   "measurement": {
     "peak": "Topp",
     "average": "Gjennomsnitt",
-    "averageExposure": "Gjennomsnittlig eksponering",
-    "dustWeek": "Høyeste daglige verdi"
+    "averageExposure": "Gjennomsnittlig eksponering"
   },
   "layout": {
     "live": "Live",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -213,10 +213,14 @@
       "safe": "Alt er bra!",
       "warning": "Oppmerksomhet anbefales!",
       "danger": "Oppmerksomhet anbefales!",
-      "criticalExposureText": "Operatører over eksponeringsgrensen. Umiddelbar oppfølging anbefales.",
-      "approachingThresholdText": "Operatører nærmer seg eksponeringsgrensen. Vurder forebyggende tiltak.",
-      "weekCriticalExposureText": "Operatører over ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales.",
-      "weekApproachingExposureText": "Operatører nærmer seg ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales.",
+      "dayView": {
+        "danger": "Operatører over eksponeringsgrensen. Umiddelbar oppfølging anbefales.",
+        "warning": "Operatører nærmer seg eksponeringsgrensen. Vurder forebyggende tiltak."
+      },
+      "weekView": {
+        "danger": "Operatører over ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales.",
+        "warning": "Operatører nærmer seg ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales."
+      },
       "oldData": "Du ser på tidligere data.",
       "day": "Dag",
       "week": "Uke"

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -50,7 +50,8 @@
   "measurement": {
     "peak": "Topp",
     "average": "Gjennomsnitt",
-    "averageExposure": "Gjennomsnittlig eksponering"
+    "averageExposure": "Gjennomsnittlig eksponering",
+    "dustWeek": "Høyeste daglige verdi"
   },
   "layout": {
     "live": "Live",
@@ -214,7 +215,11 @@
       "danger": "Oppmerksomhet anbefales!",
       "criticalExposureText": "Operatører over eksponeringsgrensen. Umiddelbar oppfølging anbefales.",
       "approachingThresholdText": "Operatører nærmer seg eksponeringsgrensen. Vurder forebyggende tiltak.",
-      "oldData": "Du ser på tidligere data."
+      "weekCriticalExposureText": "Operatører over ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales.",
+      "weekApproachingExposureText": "Operatører nærmer seg ukentlig eksponeringsgrense. Umiddelbar oppfølging anbefales.",
+      "oldData": "Du ser på tidligere data.",
+      "day": "Dag",
+      "week": "Uke"
     },
     "userStatusChart": {
       "xAxisLabel": "Prosent av faregrense",

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -21,7 +21,7 @@ import { useQuery } from "@tanstack/react-query";
 import { addWeeks, endOfDay, startOfDay } from "date-fns";
 import { ChevronDownIcon } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { UserDetails } from "./user-details";
 
@@ -33,11 +33,13 @@ export default function ForemanOverview() {
 	const [sensor, setSensor] = useQueryState("sensor", parseAsSensor);
 	const [date, setDate] = useQueryState("filterDate", parseAsTZDate.withDefault(today()));
 	const [selectedUserId, setSelectedUserId] = useQueryState("userId", parseAsString);
+	const [isWeekly, setIsWeekly] = useState(false);
 
 	const selectedDate = date;
 
-	const startDate = startOfDay(selectedDate);
-	const endDate = endOfDay(selectedDate);
+	const startDate = isWeekly ? toTZDate(startOfDay(addWeeks(selectedDate, -1))) : toTZDate(startOfDay(selectedDate));
+
+	const endDate = toTZDate(endOfDay(selectedDate));
 
 	// Foremen can only see dates within the last week
 	const minSelectableDate = startOfDay(addWeeks(today(), -1));
@@ -153,10 +155,11 @@ export default function ForemanOverview() {
 								isSubordinatesLoading={isSubordinatesLoading}
 								thresholdSummary={thresholdSummary}
 								isThresholdSummaryLoading={isThresholdSummaryLoading}
+								isWeekly={isWeekly}
+								onToggleWeekly={() => setIsWeekly((prev) => !prev)}
 							/>
-
 							{sensor ? (
-								<UserStatusChart users={subordinates ?? []} sensor={sensor} />
+								<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
 							) : (
 								<SensorSummaryGrid thresholdSummary={thresholdSummary} />
 							)}

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -136,11 +136,8 @@ export default function ForemanOverview() {
 						<Card muted={true}>
 							<ViewPicker allowedViews={["day", "week"]} withNavigationButtons={true} />
 						</Card>
-					</aside>
-				</div>
 
-				<aside className="col-start-3 row-start-2 flex flex-col gap-4">
-					<Card muted={true}>
+						<Card muted={true}>
 						<DatePicker
 							mode={"day"}
 							showWeekNumber={true}
@@ -153,7 +150,8 @@ export default function ForemanOverview() {
 							captionLayout="label"
 						/>
 					</Card>
-				</aside>
+					</aside>
+				</div>
 			</div>
 		</div>
 	);

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -130,11 +130,11 @@ export default function ForemanOverview() {
 									isWeekly={isWeekly}
 								/>
 
-								{sensor && (
+								{sensor ? (
 									<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
+								) : (
+									<SensorSummaryGrid thresholdSummary={thresholdSummary} />
 								)}
-
-								<SensorSummaryGrid thresholdSummary={thresholdSummary} />
 							</>
 						)}
 					</div>

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -22,6 +22,7 @@ import { addWeeks, endOfDay, startOfDay, subDays } from "date-fns";
 import { parseAsString, useQueryState } from "nuqs";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { UserDetails } from "./user-details";
 
 export default function ForemanOverview() {
 	const { t } = useTranslation();
@@ -54,6 +55,7 @@ export default function ForemanOverview() {
 	const selectedUser = users?.find((subordinate) => subordinate.id === selectedUserId);
 	const subordinateCount = subordinates?.length ?? 0;
 	const isUserComboboxDisabled = !users || users.length === 0;
+	const isUserSelected = selectedUser !== undefined;
 
 	const userComboboxOptions =
 		users?.map((u) => ({
@@ -113,33 +115,38 @@ export default function ForemanOverview() {
 					className="grid w-full gap-6"
 					style={{
 						gridTemplateColumns: "minmax(0, 3fr) calc(var(--spacing) * 73)",
-						gridTemplateRows: "auto",
 					}}
 				>
-					<div className="col-start-1 flex flex-col gap-12">
-						<AttentionCard
-							subordinates={subordinates ?? []}
-							isSubordinatesLoading={isSubordinatesLoading}
-							thresholdSummary={thresholdSummary}
-							isThresholdSummaryLoading={isThresholdSummaryLoading}
-							isWeekly={isWeekly}
-						/>
-
-						{sensor ? (
-							<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
+					<div className="flex flex-col gap-12">
+						{isUserSelected ? (
+							<UserDetails selectedUser={selectedUser} selectedDate={selectedDate} sensor={sensor} />
 						) : (
-							<SensorSummaryGrid thresholdSummary={thresholdSummary} />
+							<>
+								<AttentionCard
+									subordinates={subordinates ?? []}
+									isSubordinatesLoading={isSubordinatesLoading}
+									thresholdSummary={thresholdSummary}
+									isThresholdSummaryLoading={isThresholdSummaryLoading}
+									isWeekly={isWeekly}
+								/>
+
+								{sensor && (
+									<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
+								)}
+
+								<SensorSummaryGrid thresholdSummary={thresholdSummary} />
+							</>
 						)}
 					</div>
 
-					<aside className="col-start-2 flex flex-col gap-4">
+					<aside className="flex flex-col gap-4">
 						<Card muted={true}>
 							<ViewPicker allowedViews={["day", "week"]} withNavigationButtons={true} />
 						</Card>
 
 						<Card muted={true}>
 							<DatePicker
-								mode={"day"}
+								mode="day"
 								showWeekNumber={true}
 								date={date}
 								onDateChange={setDate}

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -138,18 +138,18 @@ export default function ForemanOverview() {
 						</Card>
 
 						<Card muted={true}>
-						<DatePicker
-							mode={"day"}
-							showWeekNumber={true}
-							date={date}
-							onDateChange={setDate}
-							disabled={{ before: minSelectableDate, after: maxSelectableDate }}
-							pagedNavigation={false}
-							hideNavigation={true}
-							disableNavigation={true}
-							captionLayout="label"
-						/>
-					</Card>
+							<DatePicker
+								mode={"day"}
+								showWeekNumber={true}
+								date={date}
+								onDateChange={setDate}
+								disabled={{ before: minSelectableDate, after: maxSelectableDate }}
+								pagedNavigation={false}
+								hideNavigation={true}
+								disableNavigation={true}
+								captionLayout="label"
+							/>
+						</Card>
 					</aside>
 				</div>
 			</div>

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -12,6 +12,8 @@ import { AttentionCard } from "@/features/attention-card/attention-card.js";
 import { PieChartCard } from "@/features/attention-card/pie-chart-card";
 import { TeamSummary } from "@/features/sidebar/team-summary.js";
 import { useUser } from "@/features/user/user-context";
+import { useView } from "@/features/views/use-view";
+import { ViewPicker } from "@/features/views/view-picker";
 import { useFormatDate } from "@/hooks/use-format-date";
 import { fetchSubordinatesQueryOptions, fetchThresholdSummaryQueryOptions } from "@/lib/api.js";
 import { now, parseAsTZDate, today, toTZDate } from "@/lib/date";
@@ -21,9 +23,8 @@ import { useQuery } from "@tanstack/react-query";
 import { addWeeks, endOfDay, startOfDay } from "date-fns";
 import { ChevronDownIcon } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { UserDetails } from "./user-details";
 
 export default function ForemanOverview() {
 	const { t } = useTranslation();
@@ -33,9 +34,10 @@ export default function ForemanOverview() {
 	const [sensor, setSensor] = useQueryState("sensor", parseAsSensor);
 	const [date, setDate] = useQueryState("filterDate", parseAsTZDate.withDefault(today()));
 	const [selectedUserId, setSelectedUserId] = useQueryState("userId", parseAsString);
-	const [isWeekly, setIsWeekly] = useState(false);
 
 	const selectedDate = date;
+	const { view } = useView();
+	const isWeekly = view === "week";
 
 	const startDate = isWeekly ? toTZDate(startOfDay(addWeeks(selectedDate, -1))) : toTZDate(startOfDay(selectedDate));
 
@@ -55,7 +57,6 @@ export default function ForemanOverview() {
 
 	const selectedUser = users?.find((subordinate) => subordinate.id === selectedUserId);
 	const subordinateCount = subordinates?.length ?? 0;
-	const isUserSelected = selectedUser !== undefined;
 	const isUserComboboxDisabled = !users || users.length === 0;
 
 	const userComboboxOptions =
@@ -145,26 +146,34 @@ export default function ForemanOverview() {
 					<DailyNotes />
 				</aside>
 
-				<div className="flex flex-col gap-12 md:w-3/5">
-					{isUserSelected ? (
-						<UserDetails selectedUser={selectedUser} selectedDate={selectedDate} sensor={sensor} />
-					) : (
-						<>
-							<AttentionCard
-								subordinates={subordinates ?? []}
-								isSubordinatesLoading={isSubordinatesLoading}
-								thresholdSummary={thresholdSummary}
-								isThresholdSummaryLoading={isThresholdSummaryLoading}
-								isWeekly={isWeekly}
-								onToggleWeekly={() => setIsWeekly((prev) => !prev)}
-							/>
-							{sensor ? (
-								<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
-							) : (
-								<SensorSummaryGrid thresholdSummary={thresholdSummary} />
-							)}
-						</>
-					)}
+				<div
+					className="grid w-full gap-6"
+					style={{
+						gridTemplateColumns: "minmax(0, 3fr) calc(var(--spacing) * 73)",
+						gridTemplateRows: "auto",
+					}}
+				>
+					<div className="col-start-1 flex flex-col gap-12">
+						<AttentionCard
+							subordinates={subordinates ?? []}
+							isSubordinatesLoading={isSubordinatesLoading}
+							thresholdSummary={thresholdSummary}
+							isThresholdSummaryLoading={isThresholdSummaryLoading}
+							isWeekly={isWeekly}
+						/>
+
+						{sensor ? (
+							<UserStatusChart users={subordinates ?? []} sensor={sensor} isWeekly={isWeekly} />
+						) : (
+							<SensorSummaryGrid thresholdSummary={thresholdSummary} />
+						)}
+					</div>
+
+					<aside className="col-start-2 flex flex-col gap-4">
+						<Card muted={true}>
+							<ViewPicker allowedViews={["day", "week"]} withNavigationButtons={true} />
+						</Card>
+					</aside>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## This pr:

- uses`view-picker.tsx` in the foreman overview to switch between week and day granularity views.
- updates graphs and tables accordingly.

<img width="1240" height="991" alt="image" src="https://github.com/user-attachments/assets/113b40c2-686b-42c3-a823-c5e0bda9b936" />


Closes HLTH-216