### PR TITLE
feat: move hour domain calculation to backend

### DIFF
--- a/backend/src/Controllers/DTOs/SensorDTOs/HourDomainDto.cs
+++ b/backend/src/Controllers/DTOs/SensorDTOs/HourDomainDto.cs
@@ -1,0 +1,7 @@
+namespace Backend.DTOs;
+
+public class HourDomainDto
+{
+	public int MinHourUtc { get; set; }
+	public int MaxHourUtc { get; set; }
+}

--- a/backend/src/Controllers/DTOs/SensorDTOs/SensorOverviewResponse.cs
+++ b/backend/src/Controllers/DTOs/SensorDTOs/SensorOverviewResponse.cs
@@ -1,0 +1,7 @@
+namespace Backend.DTOs;
+
+public class SensorOverviewResponse
+{
+	public IEnumerable<CombinedSensorBucketDto> Data { get; set; }
+	public HourDomainDto HourDomain { get; set; }
+}

--- a/backend/src/Controllers/DTOs/SensorDTOs/SensorResponseDto.cs
+++ b/backend/src/Controllers/DTOs/SensorDTOs/SensorResponseDto.cs
@@ -1,0 +1,7 @@
+namespace Backend.DTOs;
+
+public class SensorResponseDto
+{
+	public IEnumerable<SensorDataDto> Data { get; set; }
+	public HourDomainDto HourDomain { get; set; }
+}

--- a/backend/src/Controllers/SensorDataController.cs
+++ b/backend/src/Controllers/SensorDataController.cs
@@ -42,7 +42,7 @@ public class SensorDataController(ISensorDataService sensorDataService) : Contro
 
 			SensorResponseDto response = new() { Data = data, HourDomain = hourDomain };
 
-			return response;
+			return Ok(response);
 		}
 		catch (ArgumentException ex)
 		{

--- a/backend/src/Controllers/SensorDataController.cs
+++ b/backend/src/Controllers/SensorDataController.cs
@@ -2,6 +2,7 @@ using Backend.Data;
 using Backend.DTOs;
 using Backend.Models;
 using Backend.Services;
+using Backend.Utils;
 using Backend.Validation;
 using Microsoft.AspNetCore.Mvc;
 
@@ -15,7 +16,7 @@ public class SensorDataController(ISensorDataService sensorDataService) : Contro
 
 	[HttpPost("{sensorType}/{userId}")]
 	[ServiceFilter(typeof(ValidateFieldForSensorTypeFilter))]
-	public async Task<ActionResult<IEnumerable<SensorDataDto>>> GetAggregatedData(
+	public async Task<ActionResult<SensorResponseDto>> GetAggregatedData(
 		[FromBody] SensorDataRequestDto request,
 		[FromRoute] Guid? userId,
 		[FromRoute] SensorType sensorType
@@ -28,12 +29,20 @@ public class SensorDataController(ISensorDataService sensorDataService) : Contro
 
 		try
 		{
-			var response = await _sensorDataService.GetAggregatedDataAsync(
+			IEnumerable<SensorDataDto> data = await _sensorDataService.GetAggregatedDataAsync(
 				request,
 				userId,
 				sensorType
 			);
-			return Ok(response);
+
+			HourDomainDto hourDomain = await _sensorDataService.GetHourDomainForWeekAsync(
+				new Dictionary<SensorType, SensorDataRequestDto> { { sensorType, request } },
+				userId
+			);
+
+			SensorResponseDto response = new() { Data = data, HourDomain = hourDomain };
+
+			return response;
 		}
 		catch (ArgumentException ex)
 		{
@@ -55,7 +64,18 @@ public class SensorDataController(ISensorDataService sensorDataService) : Contro
 		[FromRoute] Guid? userId
 	)
 	{
-		var response = await _sensorDataService.GetOverviewDataAsync(requests, userId);
+		IEnumerable<CombinedSensorBucketDto> data = await _sensorDataService.GetOverviewDataAsync(
+			requests,
+			userId
+		);
+
+		HourDomainDto hourDomain = await _sensorDataService.GetHourDomainForWeekAsync(
+			requests,
+			userId
+		);
+
+		SensorOverviewResponse response = new() { Data = data, HourDomain = hourDomain };
+
 		return Ok(response);
 	}
 }

--- a/backend/src/Services/SensorDataService.cs
+++ b/backend/src/Services/SensorDataService.cs
@@ -18,6 +18,10 @@ public interface ISensorDataService
 		Dictionary<SensorType, SensorDataRequestDto> requests,
 		Guid? userId
 	);
+	Task<HourDomainDto> GetHourDomainForWeekAsync(
+		Dictionary<SensorType, SensorDataRequestDto> requests,
+		Guid? userId
+	);
 }
 
 public class SensorDataService(AppDbContext context, SignedInUserContext signedInUserContext)
@@ -168,5 +172,65 @@ public class SensorDataService(AppDbContext context, SignedInUserContext signedI
 		}
 
 		return combinedData.Values.OrderBy(bucket => bucket.Time).ToList();
+	}
+
+	public async Task<HourDomainDto> GetHourDomainForWeekAsync(
+		Dictionary<SensorType, SensorDataRequestDto> requests,
+		Guid? userId
+	)
+	{
+		HashSet<DateTime> timestamps = [];
+
+		foreach (var (sensorType, request) in requests)
+		{
+			// We always calculate domain based on the hourly data for the whole week.
+			var weekStart = GetWeekStart(request.StartTime.UtcDateTime);
+			var weekEnd = GetWeekEnd(request.StartTime.UtcDateTime);
+
+			var weekRequest = request with
+			{
+				StartTime = weekStart,
+				EndTime = weekEnd,
+				Granularity = TimeGranularity.Hour,
+			};
+
+			var weekData = await GetAggregatedDataAsync(weekRequest, userId, sensorType);
+
+			foreach (var dataPoint in weekData)
+			{
+				timestamps.Add(dataPoint.Time);
+			}
+		}
+
+		return GetHourDomain(timestamps);
+	}
+
+	private HourDomainDto GetHourDomain(IEnumerable<DateTime> timestamps)
+	{
+		int minAllowedHour = 0;
+		int maxAllowedHour = 23;
+
+		if (!timestamps.Any())
+		{
+			return new HourDomainDto { MinHourUtc = minAllowedHour, MaxHourUtc = maxAllowedHour };
+		}
+
+		int minHour = timestamps.Min().Hour;
+		int maxHour = timestamps.Max().Hour;
+
+		return new HourDomainDto { MinHourUtc = minHour, MaxHourUtc = maxHour };
+	}
+
+	private static DateTimeOffset GetWeekStart(DateTime date)
+	{
+		var dayOfWeek = (int)date.DayOfWeek;
+		var diff = date.Date.AddDays(-dayOfWeek);
+		return new DateTimeOffset(diff, TimeSpan.Zero);
+	}
+
+	private static DateTimeOffset GetWeekEnd(DateTime date)
+	{
+		var weekStart = GetWeekStart(date);
+		return weekStart.AddDays(7).AddTicks(-1);
 	}
 }

--- a/backend/tests/Backend.Tests/UnitTests/Controllers/SensorDataControllerTests.cs
+++ b/backend/tests/Backend.Tests/UnitTests/Controllers/SensorDataControllerTests.cs
@@ -60,9 +60,9 @@ public class SensorDataControllerTests
 			);
 			var okNoiseResult = noiseResult.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okNoiseResult);
-			var noiseData = okNoiseResult.Value as IEnumerable<SensorDataDto>;
+			var noiseData = okNoiseResult.Value as SensorResponseDto;
 			Assert.NotNull(noiseData);
-			Assert.Empty(noiseData);
+			Assert.Empty(noiseData.Data);
 		}
 
 		/// <summary>
@@ -86,9 +86,9 @@ public class SensorDataControllerTests
 			);
 			var okDustResult = dustResult.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okDustResult);
-			var dustData = okDustResult.Value as IEnumerable<SensorDataDto>;
+			var dustData = okDustResult.Value as SensorResponseDto;
 			Assert.NotNull(dustData);
-			Assert.Empty(dustData);
+			Assert.Empty(dustData.Data);
 		}
 
 		/// <summary>
@@ -111,9 +111,9 @@ public class SensorDataControllerTests
 			);
 			var okVibrationResult = vibrationResult.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okVibrationResult);
-			var vibrationData = okVibrationResult.Value as IEnumerable<SensorDataDto>;
+			var vibrationData = okVibrationResult.Value as SensorResponseDto;
 			Assert.NotNull(vibrationData);
-			Assert.Empty(vibrationData);
+			Assert.Empty(vibrationData.Data);
 		}
 	}
 
@@ -179,9 +179,9 @@ public class SensorDataControllerTests
 			var okResult = result.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okResult);
 
-			var data = okResult.Value as IEnumerable<SensorDataDto>;
+			var data = okResult.Value as SensorResponseDto;
 			Assert.NotNull(data);
-			Assert.Equal(2, data.Count());
+			Assert.Equal(2, data.Data.Count());
 		}
 
 		/// <summary>
@@ -228,9 +228,9 @@ public class SensorDataControllerTests
 			var okResult = result.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okResult);
 
-			var data = okResult.Value as IEnumerable<SensorDataDto>;
+			var data = okResult.Value as SensorResponseDto;
 			Assert.NotNull(data);
-			Assert.Equal(2, data.Count());
+			Assert.Equal(2, data.Data.Count());
 		}
 
 		/// <summary>
@@ -277,9 +277,9 @@ public class SensorDataControllerTests
 			var okResult = result.Result as OkObjectResult;
 			Assert.IsType<OkObjectResult>(okResult);
 
-			var data = okResult.Value as IEnumerable<SensorDataDto>;
+			var data = okResult.Value as SensorResponseDto;
 			Assert.NotNull(data);
-			Assert.Equal(2, data.Count());
+			Assert.Equal(2, data.Data.Count());
 		}
 	}
 

--- a/frontend/app/components/line-chart.tsx
+++ b/frontend/app/components/line-chart.tsx
@@ -5,7 +5,7 @@ import { useDate } from "@/features/date-picker/use-date";
 import { useFormatDate } from "@/hooks/use-format-date";
 import { type DangerLevel, DangerLevels } from "@/lib/danger-levels";
 import { toTZDate } from "@/lib/date";
-import type { SensorDataResponseDto, SensorTypeField } from "@/lib/dto";
+import type { SensorDto, SensorTypeField } from "@/lib/dto";
 import type { Sensor } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { cn } from "@/lib/utils";
@@ -22,7 +22,7 @@ const chartConfig = {
 } satisfies ChartConfig;
 
 interface LineChartProps {
-	chartData: Array<SensorDataResponseDto>;
+	chartData: Array<SensorDto>;
 	chartTitle?: string;
 	maxY: number;
 	minY: number;
@@ -116,7 +116,7 @@ export function ChartLineDefault({
 	const { warning, danger, peakDanger } = getThreshold(sensor, dustField);
 	const dangerThreshold = usePeakData && peakDanger ? peakDanger : danger;
 
-	const getValue = (data: SensorDataResponseDto) => (usePeakData ? (data.peakValue ?? data.value) : data.value);
+	const getValue = (data: SensorDto) => (usePeakData ? (data.peakValue ?? data.value) : data.value);
 
 	const maxData = chartData.toSorted((a, b) => getValue(b) - getValue(a))?.[0];
 	const minData = chartData.toSorted((a, b) => getValue(a) - getValue(b))?.[0];

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -7,12 +7,12 @@ import {
 	type Note,
 	type NoteDataRequest,
 	NoteSchema,
-	type OverviewBucketDto,
-	OverviewBucketDtoSchema,
 	type SensorDataRequestDto,
-	type SensorDataResponseDto,
-	SensorDataResponseDtoSchema,
-	type SensorOverviewDataRequestDto,
+	type SensorOverviewRequestDto,
+	type SensorOverviewResponseDto,
+	SensorOverviewResponseDtoSchema,
+	type SensorResponseDto,
+	SensorResponseDtoSchema,
 	ThresholdSummarySchema,
 	UserSchema,
 	UserWithStatusSchema,
@@ -43,7 +43,7 @@ const fetchSensorData = async (
 	sensor: Sensor,
 	sensorDataRequest: SensorDataRequestDto,
 	userId?: string,
-): Promise<Array<SensorDataResponseDto>> => {
+): Promise<SensorResponseDto> => {
 	const response = await fetchWithUserId(`sensor/${sensor}/${userId}`, {
 		method: "POST",
 		body: JSON.stringify(sensorDataRequest),
@@ -54,13 +54,13 @@ const fetchSensorData = async (
 	}
 
 	const json = await response.json();
-	return SensorDataResponseDtoSchema.array().parseAsync(json);
+	return SensorResponseDtoSchema.parseAsync(json);
 };
 
 const fetchSensorOverviewData = async (
-	requests: SensorOverviewDataRequestDto,
+	requests: SensorOverviewRequestDto,
 	userId?: string,
-): Promise<Array<OverviewBucketDto>> => {
+): Promise<SensorOverviewResponseDto> => {
 	const response = await fetchWithUserId(`sensor/overview/${userId}`, {
 		method: "POST",
 		body: JSON.stringify(requests),
@@ -71,7 +71,7 @@ const fetchSensorOverviewData = async (
 	}
 
 	const json = await response.json();
-	return OverviewBucketDtoSchema.array().parseAsync(json);
+	return SensorOverviewResponseDtoSchema.parseAsync(json);
 };
 
 export function sensorOverviewQueryOptions({
@@ -79,7 +79,7 @@ export function sensorOverviewQueryOptions({
 	userId,
 	enabled,
 }: {
-	query: SensorOverviewDataRequestDto;
+	query: SensorOverviewRequestDto;
 	userId?: string;
 	enabled?: boolean;
 }) {

--- a/frontend/app/lib/dto.ts
+++ b/frontend/app/lib/dto.ts
@@ -24,6 +24,16 @@ export const aggregateFnEnum = {
 export type AggregateFnKey = keyof typeof aggregateFnEnum;
 export type AggregateFnValue = keyof (typeof aggregateFnEnum)[AggregateFnKey];
 
+export const DEFAULT_MIN_HOUR_DOMAIN = 0;
+export const DEFAULT_MAX_HOUR_DOMAIN = 23;
+
+export const HourDomainDtoSchema = z.object({
+	minHourUtc: z.int().min(0),
+	maxHourUtc: z.int().max(23),
+});
+
+export type HourDomainDto = z.infer<typeof HourDomainDtoSchema>;
+
 export type SensorDataRequestDto = {
 	startTime: TZDate;
 	endTime: TZDate;
@@ -33,9 +43,9 @@ export type SensorDataRequestDto = {
 	clampEndTimeToNow?: boolean;
 };
 
-export type SensorOverviewDataRequestDto = Partial<Record<Sensor, SensorDataRequestDto>>;
+export type SensorOverviewRequestDto = Partial<Record<Sensor, SensorDataRequestDto>>;
 
-export const SensorDataResponseDtoSchema = z.object({
+export const SensorDtoSchema = z.object({
 	time: tzDateSchema,
 	value: z.number(),
 	peakValue: z.number().nullable(),
@@ -43,19 +53,33 @@ export const SensorDataResponseDtoSchema = z.object({
 	peakDangerLevel: DangerLevelSchema.nullable(),
 });
 
-export type SensorDataResponseDto = z.infer<typeof SensorDataResponseDtoSchema>;
+export type SensorDto = z.infer<typeof SensorDtoSchema>;
+
+export const SensorResponseDtoSchema = z.object({
+	data: SensorDtoSchema.array(),
+	hourDomain: HourDomainDtoSchema,
+});
+
+export type SensorResponseDto = z.infer<typeof SensorResponseDtoSchema>;
 
 // TODO: This should (maybe) include peakDangerLevel
-export const OverviewBucketDtoSchema = z.object({
+export const SensorOverviewBucketDtoSchema = z.object({
 	time: tzDateSchema,
 	dangerLevel: DangerLevelSchema,
 	sensorDangerLevels: z.partialRecord(SensorSchema, DangerLevelSchema),
 });
 
-export type OverviewBucketDto = z.infer<typeof OverviewBucketDtoSchema>;
+export type SensorOverviewBucketDto = z.infer<typeof SensorOverviewBucketDtoSchema>;
+
+export const SensorOverviewResponseDtoSchema = z.object({
+	data: SensorOverviewBucketDtoSchema.array(),
+	hourDomain: HourDomainDtoSchema,
+});
+
+export type SensorOverviewResponseDto = z.infer<typeof SensorOverviewResponseDtoSchema>;
 
 export type SensorDataResult = {
-	data: Array<SensorDataResponseDto> | undefined;
+	data: Array<SensorDto> | undefined;
 	isLoading: boolean;
 	isError: boolean;
 };

--- a/frontend/app/lib/sensor-query-utils.ts
+++ b/frontend/app/lib/sensor-query-utils.ts
@@ -6,7 +6,7 @@ import type {
 	AggregateFnKey,
 	GranularityKey,
 	SensorDataRequestDto,
-	SensorOverviewDataRequestDto,
+	SensorOverviewRequestDto,
 	SensorTypeField,
 } from "./dto";
 
@@ -113,7 +113,7 @@ export function buildSensorOverviewQuery(
 	options?: {
 		usePeakAggregation?: boolean;
 	},
-): SensorOverviewDataRequestDto {
+): SensorOverviewRequestDto {
 	return Object.fromEntries(
 		sensors.map((sensor) => [
 			sensor,

--- a/frontend/app/lib/time-bucket-utils.ts
+++ b/frontend/app/lib/time-bucket-utils.ts
@@ -1,10 +1,10 @@
 import type { DangerLevel } from "./danger-levels";
-import type { OverviewBucketDto, SensorDataResponseDto } from "./dto";
+import type { SensorDto, SensorOverviewBucketDto } from "./dto";
 import { type Sensor, sensors } from "./sensors";
 import type { OverviewChartRow, SummaryCounts, SummaryLevelCounts, TimeBucketStatus } from "./time-bucket-types";
 
 export function calculateSummaryCounts(
-	data: Array<SensorDataResponseDto> | Array<OverviewBucketDto>,
+	data: Array<SensorDto> | Array<SensorOverviewBucketDto>,
 	sensor?: Sensor,
 	usePeakDangerLevel?: boolean,
 ): SummaryCounts {
@@ -59,7 +59,7 @@ function incrementLevelCount(counts: SummaryLevelCounts, level: DangerLevel | nu
 	}
 }
 
-export function getDangerLevelFromData(data: SensorDataResponseDto, usePeakDangerLevel?: boolean): DangerLevel {
+export function getDangerLevelFromData(data: SensorDto, usePeakDangerLevel?: boolean): DangerLevel {
 	if (usePeakDangerLevel) {
 		return data.peakDangerLevel ?? data.dangerLevel;
 	}
@@ -67,7 +67,7 @@ export function getDangerLevelFromData(data: SensorDataResponseDto, usePeakDange
 }
 
 export function mapSensorDataToTimeBucketStatuses(
-	data: Array<SensorDataResponseDto>,
+	data: Array<SensorDto>,
 	sensor: Sensor,
 	usePeakDangerLevel?: boolean,
 ): Array<TimeBucketStatus> {
@@ -82,7 +82,7 @@ export function mapSensorDataToTimeBucketStatuses(
 	});
 }
 
-export function mapOverviewDataToTimeBucketStatuses(data: Array<OverviewBucketDto>): Array<TimeBucketStatus> {
+export function mapOverviewDataToTimeBucketStatuses(data: Array<SensorOverviewBucketDto>): Array<TimeBucketStatus> {
 	return data.map((point) => ({
 		time: point.time,
 		dangerLevel: point.dangerLevel,
@@ -91,7 +91,7 @@ export function mapOverviewDataToTimeBucketStatuses(data: Array<OverviewBucketDt
 }
 
 export function mapOverviewBucketsToChartRows(
-	data: Array<OverviewBucketDto>,
+	data: Array<SensorOverviewBucketDto>,
 	startHour: number,
 	endHour: number,
 ): Array<OverviewChartRow> {

--- a/frontend/app/lib/utils.ts
+++ b/frontend/app/lib/utils.ts
@@ -1,14 +1,15 @@
 import type { View } from "@/features/views/views";
 import type { TranslateFn } from "@/i18n/config.js";
-import type { TZDate } from "@date-fns/tz";
+import { TIMEZONE_NAME } from "@/i18n/locale";
+import { TZDate } from "@date-fns/tz";
 import { type ClassValue, clsx } from "clsx";
-import { addDays, addMonths, addWeeks, getHours, subDays, subMonths, subWeeks } from "date-fns";
+import { addDays, addMonths, addWeeks, subDays, subMonths, subWeeks } from "date-fns";
 import { CircleDashedIcon, FrownIcon, MehIcon, SmileIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import type { DangerLevel } from "./danger-levels";
-import type { SensorDataResponseDto, User } from "./dto";
+import { now } from "./date";
+import { DEFAULT_MAX_HOUR_DOMAIN, DEFAULT_MIN_HOUR_DOMAIN, type HourDomainDto, type SensorDto, type User } from "./dto";
 import type { Sensor } from "./sensors";
-import type { TimeBucketStatus } from "./time-bucket-types";
 
 const MAX_CHART_HOUR = 23;
 const MIN_CHART_HOUR = 0;
@@ -44,7 +45,7 @@ export const getNextDay = (selectedDay: TZDate, view: View): TZDate => {
 };
 
 export function computeYAxisRange(
-	data: Array<SensorDataResponseDto>,
+	data: Array<SensorDto>,
 	options?: {
 		topPadding?: number;
 		bottomPadding?: number;
@@ -80,11 +81,8 @@ export const userRoleToString = (role: User["role"], t: TranslateFn) => {
 	}
 };
 
-export function downsampleDataPoints(
-	data: Array<SensorDataResponseDto>,
-	bucketSize: number,
-): Array<SensorDataResponseDto> {
-	const result: Array<SensorDataResponseDto> = [];
+export function downsampleDataPoints(data: Array<SensorDto>, bucketSize: number): Array<SensorDto> {
+	const result: Array<SensorDto> = [];
 
 	for (let i = 0; i < data.length; i += bucketSize) {
 		const bucket = data.slice(i, i + bucketSize);
@@ -109,7 +107,7 @@ export function downsampleDataPoints(
 	return result;
 }
 
-export function downsampleSensorData(sensor: Sensor, data: Array<SensorDataResponseDto>): Array<SensorDataResponseDto> {
+export function downsampleSensorData(sensor: Sensor, data: Array<SensorDto>): Array<SensorDto> {
 	if (sensor === "vibration") {
 		return data;
 	}
@@ -156,19 +154,40 @@ export function getEmoji(dangerLevel: DangerLevel | null) {
 
 export const clampHour = (hour: number) => Math.max(Math.min(hour, MAX_CHART_HOUR), MIN_CHART_HOUR);
 
-export function getHourDomainFromBuckets(buckets: Array<TimeBucketStatus>) {
-	if (buckets.length === 0) {
+export function getHourDomain(
+	hourDomain: HourDomainDto | undefined,
+	dates: Array<TZDate> | undefined,
+	viewForPadding: View,
+): {
+	minHour: number;
+	maxHour: number;
+} {
+	if (!(dates && hourDomain)) {
+		const today = now();
 		return {
-			minHour: MIN_CHART_HOUR,
-			maxHour: MAX_CHART_HOUR,
+			minHour: convertUtcHourToLocalHour(hourDomain?.minHourUtc ?? DEFAULT_MIN_HOUR_DOMAIN, today),
+			maxHour: convertUtcHourToLocalHour(hourDomain?.maxHourUtc ?? DEFAULT_MAX_HOUR_DOMAIN, today),
 		};
 	}
 
-	const hours = buckets.map(({ time }) => getHours(time));
+	const minHours = dates.map((date) => convertUtcHourToLocalHour(hourDomain.minHourUtc, date));
 
-	// We want to show an hour before and after the actual data. We clamp the values to chart.
-	const minHour = clampHour(Math.min(...hours) - 1);
-	const maxHour = clampHour(Math.max(...hours) + 1);
+	const maxHours = dates.map((date) => convertUtcHourToLocalHour(hourDomain.maxHourUtc, date));
 
-	return { minHour, maxHour };
+	// maxHour in day views are non-inclusive, meaning if the last data point is 14:30,
+	// maxHour needs to be at least 15 to include that data point in the chart. While week and month views are inclusive.
+	// We add an additional hour of padding to ensure that the data doesn't look cut off
+	const minHourPadding = 1;
+	const maxHourPadding = viewForPadding === "day" ? 2 : 1;
+
+	return {
+		minHour: clampHour(Math.min(...minHours) - minHourPadding),
+		maxHour: clampHour(Math.max(...maxHours) + maxHourPadding),
+	};
+}
+
+function convertUtcHourToLocalHour(utcHour: number, date: TZDate): number {
+	const localDate = new TZDate(date, TIMEZONE_NAME);
+	localDate.setUTCHours(utcHour);
+	return localDate.getHours();
 }

--- a/frontend/app/routes/foreman/user-details.tsx
+++ b/frontend/app/routes/foreman/user-details.tsx
@@ -7,12 +7,18 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DateContext } from "@/features/date-picker/use-date";
 import { useExportPDF } from "@/hooks/use-export-pdf";
 import { sensorOverviewQueryOptions, sensorQueryOptions } from "@/lib/api";
-import { type Aggregation, Aggregations, type UserWithStatusDto } from "@/lib/dto";
+import {
+    type Aggregation,
+    Aggregations,
+    type SensorDto,
+    type SensorOverviewBucketDto,
+    type UserWithStatusDto,
+} from "@/lib/dto";
 import { buildSensorOverviewQuery, buildSensorQuery } from "@/lib/sensor-query-utils";
 import { type Sensor, sensors } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { mapOverviewBucketsToChartRows } from "@/lib/time-bucket-utils";
-import { computeYAxisRange, downsampleSensorData, getHourDomainFromBuckets } from "@/lib/utils";
+import { computeYAxisRange, downsampleSensorData, getHourDomain } from "@/lib/utils";
 import type { TZDate } from "@date-fns/tz";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { addDays, endOfDay, startOfDay, subDays } from "date-fns";
@@ -62,14 +68,25 @@ function AllSensorsUserOverview({
 	const [selectedUserId] = useQueryState("userId");
 	const [filterDate] = useQueryState("filterDate");
 
-	const { data, isLoading, isError } = useQuery(
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
 		sensorOverviewQueryOptions({
 			query: buildSensorOverviewQuery([...sensors], "day", selectedDate),
 			userId: selectedUser.id,
 		}),
 	);
 
-	const { minHour, maxHour } = getHourDomainFromBuckets(data ?? []);
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
+
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		"week", // The overview never shows linecharts so should always calculate hour domain with week padding
+	);
 
 	return (
 		<SensorChartCard isLoading={isLoading} isError={isError} data={data} selectedDate={selectedDate}>
@@ -105,23 +122,20 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 	const sensor: Sensor = "dust";
 
 	const query = buildSensorQuery(sensor, "day", selectedDate);
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", selectedDate, {
-		granularity: "hour",
-	});
 	const dustThreshold = getThreshold(sensor, query.field);
 	const dustPm25TwaThreshold = getThreshold(sensor, "pm25_twa");
 	const dustPm10TwaThreshold = getThreshold(sensor, "pm10_twa");
 
-	const [dataResult, weekHourRangeResult, dustTwa1Result, dustTwa25Result, dustTwa10Result] = useQueries({
+	const [
+		dataResult,
+		dustTwa1Result,
+		dustTwa25Result,
+		dustTwa10Result,
+	] = useQueries({
 		queries: [
 			sensorQueryOptions({
 				sensor,
 				query,
-				userId: selectedUser.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
 				userId: selectedUser.id,
 			}),
 			sensorQueryOptions({
@@ -154,11 +168,8 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 		],
 	});
 
-	const { data, isLoading, isError } = dataResult;
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
-	const dustTwa1Data = dustTwa1Result.data;
-	const dustTwa25Data = dustTwa25Result.data;
-	const dustTwa10Data = dustTwa10Result.data;
+	const data = dataResult?.data?.data;
+	const hourDomain = dataResult?.data?.hourDomain;
 
 	const maxValue = data ? Math.max(...data.map((point) => point.value)) : 0;
 	const minY = 0;
@@ -169,9 +180,24 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 	const averageDustExposure =
 		data && data.length > 0 ? data.reduce((sum, current) => sum + current.value, 0) / data.length : 0;
 
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		"day", // TODO: When we add a view picker we should use that here
+	);
+
+	const dustTwa1Data = dustTwa1Result?.data?.data;
+	const dustTwa25Data = dustTwa25Result?.data?.data;
+	const dustTwa10Data = dustTwa10Result?.data?.data;
+
 	return (
 		<div className="flex max-w-4xl flex-col gap-6">
-			<SensorChartCard isLoading={isLoading} isError={isError} data={data} selectedDate={selectedDate}>
+			<SensorChartCard
+				isLoading={dataResult.isLoading}
+				isError={dataResult.isError}
+				data={data}
+				selectedDate={selectedDate}
+			>
 				<DateScopedChart selectedDate={selectedDate}>
 					<div id={chartContainerId}>
 						<ChartLineDefault
@@ -210,7 +236,11 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 
 			<div className="flex flex-wrap items-center gap-4">
 				{dustTwa1Data && dustTwa1Data.length > 0 && (
-					<DustChart label="PM1 TWA" value={dustTwa1Data[0].value} thresholdValue={dustThreshold.danger} />
+					<DustChart
+						label="PM1 TWA"
+						value={dustTwa1Data[0].value}
+						thresholdValue={dustThreshold.danger}
+					/>
 				)}
 				{dustTwa25Data && dustTwa25Data.length > 0 && (
 					<DustChart
@@ -239,27 +269,17 @@ function VibrationUserChart({ selectedUser, selectedDate }: { selectedUser: User
 	const vibrationThreshold = getThreshold(sensor);
 
 	const query = buildSensorQuery(sensor, "day", selectedDate);
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", selectedDate, {
-		granularity: "hour",
-	});
 
-	const [dataResult, weekHourRangeResult] = useQueries({
-		queries: [
-			sensorQueryOptions({
-				sensor,
-				query,
-				userId: selectedUser.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
-				userId: selectedUser.id,
-			}),
-		],
-	});
+	const {data: response, isLoading, isError} = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: selectedUser.id,
+		}),
+	);
 
-	const { data, isLoading, isError } = dataResult;
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
 
 	const maxValue = data ? Math.max(...data.map((point) => point.value)) : 0;
 	const minY = 0;
@@ -268,6 +288,12 @@ function VibrationUserChart({ selectedUser, selectedDate }: { selectedUser: User
 		maxY = computeYAxisRange(data ?? []).maxY;
 	}
 	const totalVibrationExposure = data && data.length > 0 ? data[data.length - 1].value : 0;
+
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		"day", // TODO: When we add a view picker we should use that here
+	);
 
 	return (
 		<SensorChartCard isLoading={isLoading} isError={isError} data={data} selectedDate={selectedDate}>
@@ -324,28 +350,17 @@ function NoiseUserChart({ selectedUser, selectedDate }: { selectedUser: UserWith
 	const query = buildSensorQuery(sensor, "day", selectedDate, {
 		usePeakAggregation,
 	});
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", selectedDate, {
-		usePeakAggregation,
-		granularity: "hour",
-	});
 
-	const [dataResult, weekHourRangeResult] = useQueries({
-		queries: [
-			sensorQueryOptions({
-				sensor,
-				query,
-				userId: selectedUser.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
-				userId: selectedUser.id,
-			}),
-		],
-	});
+	const {data: response, isLoading, isError} = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: selectedUser.id,
+		}),
+	);
 
-	const { data, isLoading, isError } = dataResult;
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
 
 	const maxValue = data
 		? Math.max(...data.map((point) => (usePeakAggregation && point.peakValue ? point.peakValue : point.value)))
@@ -364,6 +379,12 @@ function NoiseUserChart({ selectedUser, selectedDate }: { selectedUser: UserWith
 					0,
 				) / data.length
 			: 0;
+
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		"day", // TODO: When we add a view picker we should use that here
+	);
 
 	return (
 		<div className="flex max-w-4xl flex-col gap-4">
@@ -430,7 +451,7 @@ function SensorChartCard({
 }: {
 	isLoading: boolean;
 	isError: boolean;
-	data: Array<unknown> | undefined;
+	data: Array<SensorDto> | Array<SensorOverviewBucketDto> | undefined;
 	selectedDate: TZDate;
 	children: ReactNode;
 }) {

--- a/frontend/app/routes/foreman/user-details.tsx
+++ b/frontend/app/routes/foreman/user-details.tsx
@@ -8,11 +8,11 @@ import { DateContext } from "@/features/date-picker/use-date";
 import { useExportPDF } from "@/hooks/use-export-pdf";
 import { sensorOverviewQueryOptions, sensorQueryOptions } from "@/lib/api";
 import {
-    type Aggregation,
-    Aggregations,
-    type SensorDto,
-    type SensorOverviewBucketDto,
-    type UserWithStatusDto,
+	type Aggregation,
+	Aggregations,
+	type SensorDto,
+	type SensorOverviewBucketDto,
+	type UserWithStatusDto,
 } from "@/lib/dto";
 import { buildSensorOverviewQuery, buildSensorQuery } from "@/lib/sensor-query-utils";
 import { type Sensor, sensors } from "@/lib/sensors";
@@ -126,12 +126,7 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 	const dustPm25TwaThreshold = getThreshold(sensor, "pm25_twa");
 	const dustPm10TwaThreshold = getThreshold(sensor, "pm10_twa");
 
-	const [
-		dataResult,
-		dustTwa1Result,
-		dustTwa25Result,
-		dustTwa10Result,
-	] = useQueries({
+	const [dataResult, dustTwa1Result, dustTwa25Result, dustTwa10Result] = useQueries({
 		queries: [
 			sensorQueryOptions({
 				sensor,
@@ -236,11 +231,7 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 
 			<div className="flex flex-wrap items-center gap-4">
 				{dustTwa1Data && dustTwa1Data.length > 0 && (
-					<DustChart
-						label="PM1 TWA"
-						value={dustTwa1Data[0].value}
-						thresholdValue={dustThreshold.danger}
-					/>
+					<DustChart label="PM1 TWA" value={dustTwa1Data[0].value} thresholdValue={dustThreshold.danger} />
 				)}
 				{dustTwa25Data && dustTwa25Data.length > 0 && (
 					<DustChart
@@ -270,7 +261,11 @@ function VibrationUserChart({ selectedUser, selectedDate }: { selectedUser: User
 
 	const query = buildSensorQuery(sensor, "day", selectedDate);
 
-	const {data: response, isLoading, isError} = useQuery(
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
 		sensorQueryOptions({
 			sensor,
 			query,
@@ -351,7 +346,11 @@ function NoiseUserChart({ selectedUser, selectedDate }: { selectedUser: UserWith
 		usePeakAggregation,
 	});
 
-	const {data: response, isLoading, isError} = useQuery(
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
 		sensorQueryOptions({
 			sensor,
 			query,

--- a/frontend/app/routes/operator/home.tsx
+++ b/frontend/app/routes/operator/home.tsx
@@ -13,7 +13,7 @@ import { useExportPDF } from "@/hooks/use-export-pdf";
 import { sensorOverviewQueryOptions } from "@/lib/api";
 import { buildSensorOverviewQuery } from "@/lib/sensor-query-utils";
 import { mapOverviewBucketsToChartRows, mapOverviewDataToTimeBucketStatuses } from "@/lib/time-bucket-utils";
-import { getHourDomainFromBuckets } from "@/lib/utils";
+import { getHourDomain } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useId } from "react";
 import { useTranslation } from "react-i18next";
@@ -34,11 +34,9 @@ export default function OperatorHome() {
 
 	const { user } = useUser();
 
-	const queryType = view === "day" ? "week" : view === "week" ? "month" : "day";
-
 	// NOTE: If we later add a peak noise switch here it wouldn't work because we don't return peakDangerLevel in the overview query.
 	const {
-		data: overviewBuckets,
+		data: response,
 		isLoading,
 		isError,
 	} = useQuery(
@@ -48,20 +46,14 @@ export default function OperatorHome() {
 		}),
 	);
 
-	// Retrieve week or month data to find the min and max hour the user has data for that time period
-	const queryToFindMinMaxData = useQuery(
-		sensorOverviewQueryOptions({
-			query: buildSensorOverviewQuery([...sensors], queryType, date),
-			userId: user.id,
-		}),
-	);
+	const overviewBuckets = response?.data;
+	const hourDomain = response?.hourDomain;
 
-	let minHour: number, maxHour: number;
-	if (view === "day") {
-		({ minHour, maxHour } = getHourDomainFromBuckets(queryToFindMinMaxData.data ?? []));
-	} else {
-		({ minHour, maxHour } = getHourDomainFromBuckets(overviewBuckets ?? []));
-	}
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		overviewBuckets?.map((d) => d.time),
+		"week", // The overview never shows linecharts so should always calculate hour domain with week padding
+	);
 
 	return (
 		<>

--- a/frontend/app/routes/operator/live.tsx
+++ b/frontend/app/routes/operator/live.tsx
@@ -13,7 +13,7 @@ import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { getThreshold } from "@/lib/thresholds";
 import { computeYAxisRange } from "@/lib/utils";
 import type { TZDate } from "@date-fns/tz";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { addMinutes, isWithinInterval, minutesToMilliseconds, startOfDay, startOfMinute } from "date-fns";
 import { Clock } from "lucide-react";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
@@ -46,81 +46,77 @@ export default function OperatorLiveView() {
 	// We have at most 1 data point every minute so we don't need a shorter refetch interval than that
 	const dataRefetchInterval = minutesToMilliseconds(1);
 
-	const { data: { data: dustTwa1Data } = {} } = useQuery(
-		sensorQueryOptions({
-			sensor: "dust",
-			query: buildSensorQuery("dust", "day", end, {
-				granularity: "minute",
-				aggregationFunction: "avg",
-				field: "pm1_twa",
-				startTime: start,
-				endTime: end,
-				clampEndTimeToNow: true,
+	const [dustTwa1Result, dustTwa25Result, dustTwa10Result, noiseResult, vibrationResult] = useQueries({
+		queries: [
+			sensorQueryOptions({
+				sensor: "dust",
+				query: buildSensorQuery("dust", "day", end, {
+					granularity: "minute",
+					aggregationFunction: "avg",
+					field: "pm1_twa",
+					startTime: start,
+					endTime: end,
+					clampEndTimeToNow: true,
+				}),
+				userId: targetUserId,
+				refetchInterval: dataRefetchInterval,
 			}),
-			userId: targetUserId,
-			refetchInterval: dataRefetchInterval,
-		}),
-	);
+			sensorQueryOptions({
+				sensor: "dust",
+				query: buildSensorQuery("dust", "day", end, {
+					granularity: "minute",
+					aggregationFunction: "avg",
+					field: "pm25_twa",
+					startTime: start,
+					endTime: end,
+					clampEndTimeToNow: true,
+				}),
+				userId: targetUserId,
+				refetchInterval: dataRefetchInterval,
+			}),
+			sensorQueryOptions({
+				sensor: "dust",
+				query: buildSensorQuery("dust", "day", end, {
+					granularity: "minute",
+					aggregationFunction: "avg",
+					field: "pm10_twa",
+					startTime: start,
+					endTime: end,
+					clampEndTimeToNow: true,
+				}),
+				userId: targetUserId,
+				refetchInterval: dataRefetchInterval,
+			}),
+			sensorQueryOptions({
+				sensor: "noise",
+				query: buildSensorQuery("noise", "day", end, {
+					granularity: "minute",
+					startTime: start,
+					endTime: end,
+					clampEndTimeToNow: true,
+				}),
+				userId: targetUserId,
+				refetchInterval: dataRefetchInterval,
+			}),
+			sensorQueryOptions({
+				sensor: "vibration",
+				query: buildSensorQuery("vibration", "day", end, {
+					granularity: "minute",
+					startTime: toTZDate(startOfDay(start)),
+					endTime: end,
+					clampEndTimeToNow: true,
+				}),
+				userId: targetUserId,
+				refetchInterval: dataRefetchInterval,
+			}),
+		],
+	});
 
-	const { data: { data: dustTwa25Data } = {} } = useQuery(
-		sensorQueryOptions({
-			sensor: "dust",
-			query: buildSensorQuery("dust", "day", end, {
-				granularity: "minute",
-				aggregationFunction: "avg",
-				field: "pm25_twa",
-				startTime: start,
-				endTime: end,
-				clampEndTimeToNow: true,
-			}),
-			userId: targetUserId,
-			refetchInterval: dataRefetchInterval,
-		}),
-	);
-
-	const { data: { data: dustTwa10Data } = {} } = useQuery(
-		sensorQueryOptions({
-			sensor: "dust",
-			query: buildSensorQuery("dust", "day", end, {
-				granularity: "minute",
-				aggregationFunction: "avg",
-				field: "pm10_twa",
-				startTime: start,
-				endTime: end,
-				clampEndTimeToNow: true,
-			}),
-			userId: targetUserId,
-			refetchInterval: dataRefetchInterval,
-		}),
-	);
-
-	const { data: { data: noiseData } = {} } = useQuery(
-		sensorQueryOptions({
-			sensor: "noise",
-			query: buildSensorQuery("noise", "day", end, {
-				granularity: "minute",
-				startTime: start,
-				endTime: end,
-				clampEndTimeToNow: true,
-			}),
-			userId: targetUserId,
-			refetchInterval: dataRefetchInterval,
-		}),
-	);
-
-	const { data: { data: rawVibrationData } = {} } = useQuery(
-		sensorQueryOptions({
-			sensor: "vibration",
-			query: buildSensorQuery("vibration", "day", end, {
-				granularity: "minute",
-				startTime: toTZDate(startOfDay(start)),
-				endTime: end,
-				clampEndTimeToNow: true,
-			}),
-			userId: targetUserId,
-			refetchInterval: dataRefetchInterval,
-		}),
-	);
+	const dustTwa1Data = dustTwa1Result.data?.data ?? [];
+	const dustTwa25Data = dustTwa25Result.data?.data ?? [];
+	const dustTwa10Data = dustTwa10Result.data?.data ?? [];
+	const noiseData = noiseResult.data?.data ?? [];
+	const rawVibrationData = vibrationResult.data?.data ?? [];
 
 	// Since vibration is cumulative over the day we have to fetch data from the start of the day and then filter it to the selected time range
 	const vibrationData = useMemo(() => {

--- a/frontend/app/routes/operator/live.tsx
+++ b/frontend/app/routes/operator/live.tsx
@@ -8,7 +8,7 @@ import { SecurityRegulationsCard } from "@/features/security-regulations-card/se
 import { useUser } from "@/features/user/user-context";
 import { sensorQueryOptions } from "@/lib/api";
 import { now, toTZDate } from "@/lib/date";
-import type { SensorDataResponseDto } from "@/lib/dto";
+import type { SensorDto } from "@/lib/dto";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { getThreshold } from "@/lib/thresholds";
 import { computeYAxisRange } from "@/lib/utils";
@@ -46,7 +46,7 @@ export default function OperatorLiveView() {
 	// We have at most 1 data point every minute so we don't need a shorter refetch interval than that
 	const dataRefetchInterval = minutesToMilliseconds(1);
 
-	const { data: dustTwa1Data } = useQuery(
+	const { data: { data: dustTwa1Data } = {} } = useQuery(
 		sensorQueryOptions({
 			sensor: "dust",
 			query: buildSensorQuery("dust", "day", end, {
@@ -62,7 +62,7 @@ export default function OperatorLiveView() {
 		}),
 	);
 
-	const { data: dustTwa25Data } = useQuery(
+	const { data: { data: dustTwa25Data } = {} } = useQuery(
 		sensorQueryOptions({
 			sensor: "dust",
 			query: buildSensorQuery("dust", "day", end, {
@@ -78,7 +78,7 @@ export default function OperatorLiveView() {
 		}),
 	);
 
-	const { data: dustTwa10Data } = useQuery(
+	const { data: { data: dustTwa10Data } = {} } = useQuery(
 		sensorQueryOptions({
 			sensor: "dust",
 			query: buildSensorQuery("dust", "day", end, {
@@ -94,7 +94,7 @@ export default function OperatorLiveView() {
 		}),
 	);
 
-	const { data: noiseData } = useQuery(
+	const { data: { data: noiseData } = {} } = useQuery(
 		sensorQueryOptions({
 			sensor: "noise",
 			query: buildSensorQuery("noise", "day", end, {
@@ -108,7 +108,7 @@ export default function OperatorLiveView() {
 		}),
 	);
 
-	const { data: rawVibrationData } = useQuery(
+	const { data: { data: rawVibrationData } = {} } = useQuery(
 		sensorQueryOptions({
 			sensor: "vibration",
 			query: buildSensorQuery("vibration", "day", end, {
@@ -278,7 +278,7 @@ interface LiveExposureCardProps {
 	exposureField?: "pm1_twa" | "pm25_twa" | "pm10_twa";
 	exposureUnitLabel: string;
 	chartUnitLabel: string;
-	data: Array<SensorDataResponseDto>;
+	data: Array<SensorDto>;
 	minTime: TZDate;
 	maxTime: TZDate;
 	chartClassName?: string;

--- a/frontend/app/routes/operator/sensors/dust.tsx
+++ b/frontend/app/routes/operator/sensors/dust.tsx
@@ -12,8 +12,8 @@ import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { Sensor } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { mapSensorDataToTimeBucketStatuses } from "@/lib/time-bucket-utils";
-import { computeYAxisRange, downsampleSensorData, getHourDomainFromBuckets } from "@/lib/utils";
-import { useQueries } from "@tanstack/react-query";
+import { computeYAxisRange, downsampleSensorData, getHourDomain } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { useId } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -30,31 +30,22 @@ export default function Dust() {
 
 	const query = buildSensorQuery(sensor, view, date);
 
-	// Retrieve week data to find the min and max hour the user has data
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", date, {
-		granularity: "hour",
-	});
-
 	const dustThreshold = getThreshold(sensor, query.field);
 
-	const [dataResult, weekHourRangeResult] = useQueries({
-		queries: [
-			sensorQueryOptions({
-				sensor,
-				query,
-				userId: user.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
-				userId: user.id,
-			}),
-		],
-	});
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: user.id,
+		}),
+	);
 
-	const { data, isLoading, isError } = dataResult;
-
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
 
 	const maxValue = data ? Math.max(...data.map((d) => d.value)) : 0;
 
@@ -67,6 +58,8 @@ export default function Dust() {
 	const calendarData = mapSensorDataToTimeBucketStatuses(data ?? [], sensor);
 	const averageExposure =
 		data && data.length > 0 ? data.reduce((sum, current) => sum + current.value, 0) / data.length : 0;
+
+	const { minHour, maxHour } = getHourDomain(hourDomain, data?.map((d) => d.time) ?? [], view);
 
 	return (
 		<div className="flex flex-1 flex-col gap-4">

--- a/frontend/app/routes/operator/sensors/noise.tsx
+++ b/frontend/app/routes/operator/sensors/noise.tsx
@@ -14,11 +14,7 @@ import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { Sensor } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { mapSensorDataToTimeBucketStatuses } from "@/lib/time-bucket-utils";
-import {
-	computeYAxisRange,
-	downsampleSensorData,
-	getHourDomain,
-} from "@/lib/utils";
+import { computeYAxisRange, downsampleSensorData, getHourDomain } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useId } from "react";
@@ -70,11 +66,7 @@ export default function Noise() {
 	);
 
 	const maxValue = data
-		? Math.max(
-				...data.map((d) =>
-					usePeakAggregation && d.peakValue ? d.peakValue : d.value,
-				),
-			)
+		? Math.max(...data.map((d) => (usePeakAggregation && d.peakValue ? d.peakValue : d.value)))
 		: 0;
 
 	const minY = 0;
@@ -85,31 +77,19 @@ export default function Noise() {
 		}).maxY;
 	}
 
-	const calendarData = mapSensorDataToTimeBucketStatuses(
-		data ?? [],
-		sensor,
-		usePeakAggregation,
-	);
+	const calendarData = mapSensorDataToTimeBucketStatuses(data ?? [], sensor, usePeakAggregation);
 
 	const averageExposure =
 		data && data.length > 0
-			? data.reduce(
-					(sum, d) =>
-						sum + (usePeakAggregation && d.peakValue ? d.peakValue : d.value),
-					0,
-				) / data.length
+			? data.reduce((sum, d) => sum + (usePeakAggregation && d.peakValue ? d.peakValue : d.value), 0) /
+				data.length
 			: 0;
 
 	return (
 		<div className="flex flex-1 flex-col gap-4">
-			<Tabs
-				value={aggregation}
-				onValueChange={(value) => setAggregation(value as Aggregation)}
-			>
+			<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
 				<TabsList>
-					<TabsTrigger value="average">
-						{t(($) => $.measurement.average)}
-					</TabsTrigger>
+					<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
 					<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
 				</TabsList>
 			</Tabs>
@@ -123,17 +103,9 @@ export default function Noise() {
 					<p>{t(($) => $.common.error)}</p>
 				</Card>
 			) : view === "month" ? (
-				<CalendarWidget
-					selectedDay={date}
-					selectedAggregation={aggregation}
-					data={calendarData}
-				/>
+				<CalendarWidget selectedDay={date} selectedAggregation={aggregation} data={calendarData} />
 			) : view === "week" ? (
-				<WeekWidget
-					dayStartHour={minHour}
-					dayEndHour={maxHour}
-					data={calendarData}
-				/>
+				<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
 			) : !data || data.length === 0 ? (
 				<Card className="flex h-24 w-full items-center">
 					<CardTitle>
@@ -188,12 +160,7 @@ export default function Noise() {
 								}
 								dangerLevel="danger"
 							/>
-							{!usePeakAggregation && (
-								<ThresholdLine
-									y={noiseThreshold.warning}
-									dangerLevel="warning"
-								/>
-							)}
+							{!usePeakAggregation && <ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />}
 						</ChartLineDefault>
 					</div>
 				</div>

--- a/frontend/app/routes/operator/sensors/noise.tsx
+++ b/frontend/app/routes/operator/sensors/noise.tsx
@@ -14,8 +14,12 @@ import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { Sensor } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { mapSensorDataToTimeBucketStatuses } from "@/lib/time-bucket-utils";
-import { computeYAxisRange, downsampleSensorData, getHourDomainFromBuckets } from "@/lib/utils";
-import { useQueries } from "@tanstack/react-query";
+import {
+	computeYAxisRange,
+	downsampleSensorData,
+	getHourDomain,
+} from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useId } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,33 +48,33 @@ export default function Noise() {
 		usePeakAggregation,
 	});
 
-	// Retrieve week data to find the min and max hour the user has data
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", date, {
-		usePeakAggregation,
-		granularity: "hour",
-	});
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: user.id,
+		}),
+	);
 
-	const [dataResult, weekHourRangeResult] = useQueries({
-		queries: [
-			sensorQueryOptions({
-				sensor,
-				query,
-				userId: user.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
-				userId: user.id,
-			}),
-		],
-	});
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
 
-	const { data, isLoading, isError } = dataResult;
-
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		view,
+	);
 
 	const maxValue = data
-		? Math.max(...data.map((d) => (usePeakAggregation && d.peakValue ? d.peakValue : d.value)))
+		? Math.max(
+				...data.map((d) =>
+					usePeakAggregation && d.peakValue ? d.peakValue : d.value,
+				),
+			)
 		: 0;
 
 	const minY = 0;
@@ -81,19 +85,31 @@ export default function Noise() {
 		}).maxY;
 	}
 
-	const calendarData = mapSensorDataToTimeBucketStatuses(data ?? [], sensor, usePeakAggregation);
+	const calendarData = mapSensorDataToTimeBucketStatuses(
+		data ?? [],
+		sensor,
+		usePeakAggregation,
+	);
 
 	const averageExposure =
 		data && data.length > 0
-			? data.reduce((sum, d) => sum + (usePeakAggregation && d.peakValue ? d.peakValue : d.value), 0) /
-				data.length
+			? data.reduce(
+					(sum, d) =>
+						sum + (usePeakAggregation && d.peakValue ? d.peakValue : d.value),
+					0,
+				) / data.length
 			: 0;
 
 	return (
 		<div className="flex flex-1 flex-col gap-4">
-			<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
+			<Tabs
+				value={aggregation}
+				onValueChange={(value) => setAggregation(value as Aggregation)}
+			>
 				<TabsList>
-					<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
+					<TabsTrigger value="average">
+						{t(($) => $.measurement.average)}
+					</TabsTrigger>
 					<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
 				</TabsList>
 			</Tabs>
@@ -107,9 +123,17 @@ export default function Noise() {
 					<p>{t(($) => $.common.error)}</p>
 				</Card>
 			) : view === "month" ? (
-				<CalendarWidget selectedDay={date} selectedAggregation={aggregation} data={calendarData} />
+				<CalendarWidget
+					selectedDay={date}
+					selectedAggregation={aggregation}
+					data={calendarData}
+				/>
 			) : view === "week" ? (
-				<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
+				<WeekWidget
+					dayStartHour={minHour}
+					dayEndHour={maxHour}
+					data={calendarData}
+				/>
 			) : !data || data.length === 0 ? (
 				<Card className="flex h-24 w-full items-center">
 					<CardTitle>
@@ -164,7 +188,12 @@ export default function Noise() {
 								}
 								dangerLevel="danger"
 							/>
-							{!usePeakAggregation && <ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />}
+							{!usePeakAggregation && (
+								<ThresholdLine
+									y={noiseThreshold.warning}
+									dangerLevel="warning"
+								/>
+							)}
 						</ChartLineDefault>
 					</div>
 				</div>

--- a/frontend/app/routes/operator/sensors/sensor-layout.tsx
+++ b/frontend/app/routes/operator/sensors/sensor-layout.tsx
@@ -84,7 +84,7 @@ export default function SensorLayout() {
 
 	const ViewIcon = getViewIcon(view);
 
-	const summary = calculateSummaryCounts(response.data ?? [], sensor ?? undefined, usePeakAggregation);
+	const summary = calculateSummaryCounts(response.data?.data ?? [], sensor ?? undefined, usePeakAggregation);
 
 	return (
 		<div

--- a/frontend/app/routes/operator/sensors/vibration.tsx
+++ b/frontend/app/routes/operator/sensors/vibration.tsx
@@ -32,7 +32,11 @@ export default function Vibration() {
 
 	const query = buildSensorQuery(sensor, view, date);
 
-	const {data: response, isLoading, isError} = useQuery(
+	const {
+		data: response,
+		isLoading,
+		isError,
+	} = useQuery(
 		sensorQueryOptions({
 			sensor,
 			query,

--- a/frontend/app/routes/operator/sensors/vibration.tsx
+++ b/frontend/app/routes/operator/sensors/vibration.tsx
@@ -12,8 +12,8 @@ import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { Sensor } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { mapSensorDataToTimeBucketStatuses } from "@/lib/time-bucket-utils";
-import { computeYAxisRange, downsampleSensorData, getHourDomainFromBuckets } from "@/lib/utils";
-import { useQueries } from "@tanstack/react-query";
+import { computeYAxisRange, downsampleSensorData, getHourDomain } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
 import { useId } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,29 +32,22 @@ export default function Vibration() {
 
 	const query = buildSensorQuery(sensor, view, date);
 
-	// Retrieve week data to find the min and max hour the user has data
-	const weekHourRangeQuery = buildSensorQuery(sensor, "week", date, {
-		granularity: "hour",
-	});
+	const {data: response, isLoading, isError} = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: user.id,
+		}),
+	);
 
-	const [dataResult, weekHourRangeResult] = useQueries({
-		queries: [
-			sensorQueryOptions({
-				sensor,
-				query,
-				userId: user.id,
-			}),
-			sensorQueryOptions({
-				sensor,
-				query: weekHourRangeQuery,
-				userId: user.id,
-			}),
-		],
-	});
+	const data = response?.data;
+	const hourDomain = response?.hourDomain;
 
-	const { data, isLoading, isError } = dataResult;
-
-	const { minHour, maxHour } = getHourDomainFromBuckets(weekHourRangeResult.data ?? []);
+	const { minHour, maxHour } = getHourDomain(
+		hourDomain,
+		data?.map((d) => d.time),
+		view,
+	);
 
 	const maxValue = data ? Math.max(...data.map((d) => d.value)) : 0;
 


### PR DESCRIPTION
The domain for the week of the requested date now gets returned as { minHour, maxHour} in every sensor request