### PR TITLE
feat(Foreman): make operator and sensor icons clickable in map

### DIFF
--- a/frontend/app/features/location-map/hall-operator-list.tsx
+++ b/frontend/app/features/location-map/hall-operator-list.tsx
@@ -53,8 +53,12 @@ export const HallOperatorList = ({
 									<TableCell>
 										<Link
 											to={`/foreman/?userId=${operator.id}`}
-											title={`View ${operator.username}`}
-											aria-label={`View user ${operator.username}`}
+											title={t(($) => $.foremanDashboard.siteMap.viewUser, {
+												username: operator.username,
+											})}
+											aria-label={t(($) => $.foremanDashboard.siteMap.viewUserAria, {
+												username: operator.username,
+											})}
 											className="relative block text-muted-foreground hover:text-white"
 										>
 											{operator.username}
@@ -95,7 +99,10 @@ const HallOperatorListItem = ({ operator, sensor }: HallOperatorListItemProps) =
 			<Link
 				to={`/foreman?userId=${operator.id}&sensor=${sensor}`}
 				title={title}
-				aria-label={`View ${sensor} data for ${operator.username}`}
+				aria-label={t(($) => $.foremanDashboard.siteMap.viewSensorData, {
+					username: operator.username,
+					sensor: t(($$) => $$.sensors[sensor]).toLowerCase(),
+				})}
 				className="block w-fit"
 			>
 				<SensorIcon

--- a/frontend/app/features/location-map/hall-operator-list.tsx
+++ b/frontend/app/features/location-map/hall-operator-list.tsx
@@ -7,6 +7,7 @@ import type { UserWithStatusDto } from "@/lib/dto";
 import { type Sensor, sensors } from "@/lib/sensors";
 import { ChevronDownIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
 
 export interface HallOperatorListProps {
 	sensor: Sensor | "all";
@@ -47,21 +48,27 @@ export const HallOperatorList = ({
 								</TableCell>
 							</TableRow>
 						) : (
-							operators.map((operator) => {
-								return (
-									<TableRow key={operator.id} className="text-muted-foreground">
-										{/* TODO: Link to user stats page */}
-										<TableCell>{operator.username}</TableCell>
-										{sensor === "all" ? (
-											sensors.map((s) => (
-												<HallOperatorListItem key={s} operator={operator} sensor={s} />
-											))
-										) : (
-											<HallOperatorListItem operator={operator} sensor={sensor} />
-										)}
-									</TableRow>
-								);
-							})
+							operators.map((operator) => (
+								<TableRow key={operator.id} className="text-muted-foreground">
+									<TableCell>
+										<Link
+											to={`/foreman/?userId=${operator.id}`}
+											title={`View ${operator.username}`}
+											aria-label={`View user ${operator.username}`}
+											className="relative block text-muted-foreground hover:text-white"
+										>
+											{operator.username}
+										</Link>
+									</TableCell>
+									{sensor === "all" ? (
+										sensors.map((s) => (
+											<HallOperatorListItem key={s} operator={operator} sensor={s} />
+										))
+									) : (
+										<HallOperatorListItem operator={operator} sensor={sensor} />
+									)}
+								</TableRow>
+							))
 						)}
 					</TableBody>
 				</Table>
@@ -85,7 +92,19 @@ const HallOperatorListItem = ({ operator, sensor }: HallOperatorListItemProps) =
 
 	return (
 		<TableCell className="items-center">
-			<SensorIcon type={sensor} size="xs" dangerLevel={dangerLevel ?? "safe"} className="w-fit" title={title} />
+			<Link
+				to={`/foreman?userId=${operator.id}&sensor=${sensor}`}
+				title={title}
+				aria-label={`View ${sensor} data for ${operator.username}`}
+				className="block w-fit"
+			>
+				<SensorIcon
+					type={sensor}
+					size="xs"
+					dangerLevel={dangerLevel}
+					className="w-fit cursor-pointer transition-transform hover:scale-110"
+				/>
+			</Link>
 		</TableCell>
 	);
 };

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -231,6 +231,9 @@
     "siteMap": {
       "title": "Site map",
       "noOperators": "No operators in hall",
+      "viewUser": "View {{username}}",
+      "viewUserAria": "View user {{username}}",
+      "viewSensorData": "View {{sensor}} data for {{username}}",
       "operatorSensorStatus": {
         "danger": "Above exposure limit for {{sensor}}",
         "warning": "Approaching exposure limit for {{sensor}}",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -231,6 +231,9 @@
     "siteMap": {
       "title": "Områdekart",
       "noOperators": "Ingen operatører i bygg",
+      "viewUser": "Se {{username}}",
+      "viewUserAria": "Se bruker {{username}}",
+      "viewSensorData": "Se {{sensor}} data for {{username}}",
       "operatorSensorStatus": {
         "danger": "Over grenseverdi for {{sensor}}",
         "warning": "Nær grenseverdi for {{sensor}}",


### PR DESCRIPTION
## This pr:

- Makes operators in the map function clickable and routes to that operators page.
- Makes the sensor icons in the map function clickable as well.

Closes HLTH-205