### PR TITLE
feat(Operator): highlight todays date in calendar widget

### DIFF
--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -157,6 +157,7 @@ type CustomDayProps = {
 function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: CustomDayProps) {
 	const dangerLevel = getDayDangerLevel(toTZDate(day.date), data);
 	const disabled = dangerLevel === null;
+	const isToday = buttonProps.modifiers?.today;
 
 	let bgClassname = "";
 	if (dangerLevel === "safe") {
@@ -168,7 +169,12 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 	}
 
 	return (
-		<button type="button" disabled={disabled} className={cn("relative h-full w-full rounded-lg")} {...buttonProps}>
+		<button
+			type="button"
+			disabled={disabled}
+			className={cn("relative h-full w-full rounded-lg", className)}
+			{...buttonProps}
+		>
 			<div
 				className={cn(
 					"h-full w-full rounded-lg",
@@ -182,7 +188,14 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 					disabled && "text-muted-foreground",
 				)}
 			>
-				{day.date.getDate()}
+				<span
+					className={cn(
+						"flex h-7 w-7 items-center justify-center rounded-full",
+						isToday && "bg-neutral-800 text-white",
+					)}
+				>
+					{day.date.getDate()}
+				</span>
 			</span>
 			<DangerLevelDots dangerLevel={dangerLevel ?? null} className="absolute right-2 bottom-2" />
 		</button>

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -190,7 +190,7 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 			>
 				<span
 					className={cn(
-						"flex h-7 w-7 items-center justify-center rounded-full",
+						"flex size-7 items-center justify-center rounded-full",
 						isToday && "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-black",
 					)}
 				>

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -191,7 +191,7 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 				<span
 					className={cn(
 						"flex size-7 items-center justify-center rounded-full",
-						isToday && "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-black",
+						isToday && "bg-neutral-800 text-foreground dark:bg-neutral-200",
 					)}
 				>
 					{day.date.getDate()}

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -191,7 +191,7 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 				<span
 					className={cn(
 						"flex h-7 w-7 items-center justify-center rounded-full",
-						isToday && "bg-neutral-800 text-white",
+						isToday && "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-black",
 					)}
 				>
 					{day.date.getDate()}

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -191,7 +191,7 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 				<span
 					className={cn(
 						"flex size-7 items-center justify-center rounded-full",
-						isToday && "bg-neutral-800 text-foreground dark:bg-neutral-200",
+						isToday && "bg-foreground text-background",
 					)}
 				>
 					{day.date.getDate()}


### PR DESCRIPTION
Light mode:
<img width="333" height="265" alt="image" src="https://github.com/user-attachments/assets/bc6ed206-4f2b-4f64-a875-f0de8ec6d7f6" />

Dark mode:
<img width="236" height="181" alt="image" src="https://github.com/user-attachments/assets/ff7b3292-baee-487c-840c-d087f86cf229" />
