### PR TITLE
feat(Foreman): add header above pie charts

### DIFF
--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -206,6 +206,7 @@
       "pieChart": {
         "noData": "No data found for this date"
       },
+      "sensor": "Sensors",
       "statCards": {
         "danger": {
           "label": "Above limit value",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -207,6 +207,7 @@
       "pieChart": {
         "noData": "Ingen data funnet for denne datoen"
       },
+      "sensor": "Sensorer",
       "statCards": {
         "danger": {
           "label": "Over grenseverdi",

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -194,7 +194,9 @@ function SensorSummaryGrid({ thresholdSummary }: { thresholdSummary: ThresholdSu
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="font-extralight text-2xl text-color-muted">{t(($) => $.foremanDashboard.overview.sensor)}</div>
+			<div className="font-extralight text-2xl text-color-muted">
+				{t(($) => $.foremanDashboard.overview.sensor)}
+			</div>
 			<div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
 				{sensors.map((sensorType: Sensor) => (
 					<PieChartCard

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -194,7 +194,7 @@ function SensorSummaryGrid({ thresholdSummary }: { thresholdSummary: ThresholdSu
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="font-extralight text-2xl text-white">{t(($) => $.foremanDashboard.overview.sensor)}</div>
+			<div className="font-extralight text-2xl text-color-muted">{t(($) => $.foremanDashboard.overview.sensor)}</div>
 			<div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
 				{sensors.map((sensorType: Sensor) => (
 					<PieChartCard

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -193,6 +193,10 @@ function SensorSummaryGrid({ thresholdSummary }: { thresholdSummary: ThresholdSu
 	}
 
 	return (
+		<div className="flex flex-col gap-4">
+			<div className="text-2xl text-white font-extralight">
+				{t(($) => $.foremanDashboard.overview.sensor)}
+			</div>
 		<div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
 			{sensors.map((sensorType: Sensor) => (
 				<PieChartCard
@@ -219,6 +223,7 @@ function SensorSummaryGrid({ thresholdSummary }: { thresholdSummary: ThresholdSu
 					sensorType={sensorType}
 				/>
 			))}
+		</div>
 		</div>
 	);
 }

--- a/frontend/app/routes/foreman/overview.tsx
+++ b/frontend/app/routes/foreman/overview.tsx
@@ -194,36 +194,34 @@ function SensorSummaryGrid({ thresholdSummary }: { thresholdSummary: ThresholdSu
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="text-2xl text-white font-extralight">
-				{t(($) => $.foremanDashboard.overview.sensor)}
+			<div className="font-extralight text-2xl text-white">{t(($) => $.foremanDashboard.overview.sensor)}</div>
+			<div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
+				{sensors.map((sensorType: Sensor) => (
+					<PieChartCard
+						data={{
+							safe: {
+								name: "Safe",
+								value: thresholdSummary[sensorType].safe,
+								label: t(($) => $.foremanDashboard.overview.statCards.safe.label),
+							},
+							warning: {
+								name: "Warning",
+								value: thresholdSummary[sensorType].warning,
+								label: t(($) => $.foremanDashboard.overview.statCards.warning.label),
+							},
+							danger: {
+								name: "Danger",
+								value: thresholdSummary[sensorType].danger,
+								label: t(($) => $.foremanDashboard.overview.statCards.danger.label),
+							},
+						}}
+						label={t(($) => $.sensors[sensorType])}
+						to={`?sensor=${sensorType}`}
+						key={sensorType}
+						sensorType={sensorType}
+					/>
+				))}
 			</div>
-		<div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
-			{sensors.map((sensorType: Sensor) => (
-				<PieChartCard
-					data={{
-						safe: {
-							name: "Safe",
-							value: thresholdSummary[sensorType].safe,
-							label: t(($) => $.foremanDashboard.overview.statCards.safe.label),
-						},
-						warning: {
-							name: "Warning",
-							value: thresholdSummary[sensorType].warning,
-							label: t(($) => $.foremanDashboard.overview.statCards.warning.label),
-						},
-						danger: {
-							name: "Danger",
-							value: thresholdSummary[sensorType].danger,
-							label: t(($) => $.foremanDashboard.overview.statCards.danger.label),
-						},
-					}}
-					label={t(($) => $.sensors[sensorType])}
-					to={`?sensor=${sensorType}`}
-					key={sensorType}
-					sensorType={sensorType}
-				/>
-			))}
-		</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## This pr:

- adds header above pie charts in the foreman overview page.
<img width="1560" height="1240" alt="image" src="https://github.com/user-attachments/assets/80d8740c-b36b-4752-828b-0ae32593a356" />

Closes HLTH-260
 