### PR TITLE
feat(frontend): create trend line chart

### DIFF
--- a/frontend/app/components/exposure-line-chart/exposure-dot.tsx
+++ b/frontend/app/components/exposure-line-chart/exposure-dot.tsx
@@ -1,0 +1,15 @@
+import { dangerlevelStyles, getDangerLevel } from "@/lib/danger-levels";
+import { normalizeDangerLevelForPeakForLineChart } from "@/lib/utils";
+import type { ActiveDotProps } from "recharts";
+
+type Props = ActiveDotProps & { warning: number; danger: number };
+
+export const ExposureDot = ({ cx, cy, value, warning, danger, isPeak }: Props & { isPeak?: boolean }) => {
+	let dangerLevel = getDangerLevel(value, warning, danger);
+
+	dangerLevel = normalizeDangerLevelForPeakForLineChart(dangerLevel, isPeak);
+
+	const fillColor = dangerlevelStyles[dangerLevel].color;
+
+	return <circle cx={cx} cy={cy} r={6} fill={fillColor} />;
+};

--- a/frontend/app/components/exposure-line-chart/exposure-line-chart-gradient-stops.tsx
+++ b/frontend/app/components/exposure-line-chart/exposure-line-chart-gradient-stops.tsx
@@ -1,0 +1,68 @@
+import { dangerlevelStyles, getDangerLevel } from "@/lib/danger-levels";
+import { normalizeDangerLevelForPeakForLineChart } from "@/lib/utils";
+
+interface ExposureLineChartGradientStopsProps {
+	values: Array<number>;
+	warningThreshold: number;
+	dangerThreshold: number;
+	usePeakData?: boolean;
+}
+
+export function ExposureLineChartGradientStops({
+	values,
+	warningThreshold,
+	dangerThreshold,
+	usePeakData,
+}: ExposureLineChartGradientStopsProps) {
+	const minValue = values.length > 0 ? Math.min(...values) : 0;
+	const maxValue = values.length > 0 ? Math.max(...values) : 0;
+
+	let minDangerLevel = getDangerLevel(minValue, warningThreshold, dangerThreshold);
+	let maxDangerLevel = getDangerLevel(maxValue, warningThreshold, dangerThreshold);
+
+	minDangerLevel = normalizeDangerLevelForPeakForLineChart(minDangerLevel, usePeakData);
+	maxDangerLevel = normalizeDangerLevelForPeakForLineChart(maxDangerLevel, usePeakData);
+
+	const uniformDangerLevel = minDangerLevel === maxDangerLevel ? minDangerLevel : undefined;
+
+	const getOffset = (y: number) => {
+		if (maxValue === minValue) {
+			return "0%";
+		}
+
+		return `${((maxValue - y) / (maxValue - minValue)) * 100}%`;
+	};
+
+	const dangerOffset = getOffset(dangerThreshold);
+	const warningOffset = getOffset(warningThreshold);
+
+	// If all values fall within the same danger level, use a solid color for the line instead of a gradient
+	if (uniformDangerLevel) {
+		const dangerLevelColor = dangerlevelStyles[uniformDangerLevel].color;
+		return (
+			<>
+				<stop offset="0%" stopColor={dangerLevelColor} />
+				<stop offset="100%" stopColor={dangerLevelColor} />
+			</>
+		);
+	}
+
+	return (
+		<>
+			<stop offset={dangerOffset} stopColor="var(--danger)" />
+
+			{/* Only show the warning gradient for non-peak data */}
+			{usePeakData ? (
+				<stop offset={dangerOffset} stopColor="var(--safe)" />
+			) : (
+				<>
+					<stop offset={dangerOffset} stopColor="var(--warning)" />
+					<stop offset={warningOffset} stopColor="var(--warning)" />
+					<stop offset={warningOffset} stopColor="var(--safe)" />
+				</>
+			)}
+
+			<stop offset="100%" stopColor="var(--safe)" />
+		</>
+	);
+}

--- a/frontend/app/components/exposure-line-chart/exposure-line-chart.tsx
+++ b/frontend/app/components/exposure-line-chart/exposure-line-chart.tsx
@@ -223,7 +223,7 @@ export function ExposureLineChart({
 								/>
 							</div>
 						)}
-					></Legend>
+					/>
 				)}
 			</LineChart>
 		</ChartContainer>

--- a/frontend/app/components/exposure-line-chart/exposure-line-chart.tsx
+++ b/frontend/app/components/exposure-line-chart/exposure-line-chart.tsx
@@ -1,7 +1,7 @@
 import { ExposureTooltip } from "@/components/exposure-line-chart/exposure-tooltip";
 import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
 import { useFormatDate } from "@/hooks/use-format-date";
-import { type DangerLevel, DangerLevels, dangerlevelStyles, getDangerLevel } from "@/lib/danger-levels";
+import { DangerLevels } from "@/lib/danger-levels";
 import { toTZDate } from "@/lib/date";
 import type { SensorDto, SensorTypeField } from "@/lib/dto";
 import type { Sensor, SensorUnit } from "@/lib/sensors";
@@ -10,17 +10,10 @@ import { cn, formatSensorValue } from "@/lib/utils";
 import { TZDate } from "@date-fns/tz";
 import { type PropsWithChildren, useId } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	type ActiveDotProps,
-	CartesianGrid,
-	Legend,
-	Line,
-	LineChart,
-	XAxis,
-	type XAxisTickContentProps,
-	YAxis,
-} from "recharts";
+import { CartesianGrid, Legend, Line, LineChart, XAxis, type XAxisTickContentProps, YAxis } from "recharts";
 import type { CurveType } from "recharts/types/shape/Curve";
+import { ExposureDot } from "./exposure-dot";
+import { ExposureLineChartGradientStops } from "./exposure-line-chart-gradient-stops";
 import { ThresholdLegend } from "./threshold-legend";
 
 const Y_AXIS_WIDTH = 60;
@@ -182,7 +175,7 @@ export function ExposureLineChart({
 
 				<defs>
 					<linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
-						<GradientStops
+						<ExposureLineChartGradientStops
 							values={transformedData.map((point) => point.value)}
 							warningThreshold={warning}
 							dangerThreshold={dangerThreshold}
@@ -199,7 +192,7 @@ export function ExposureLineChart({
 					animationDuration={0}
 					dot={false}
 					activeDot={(props) => (
-						<Dot {...props} warning={warning} danger={dangerThreshold} isPeak={usePeakData} />
+						<ExposureDot {...props} warning={warning} danger={dangerThreshold} isPeak={usePeakData} />
 					)}
 				/>
 				{children}
@@ -229,18 +222,6 @@ export function ExposureLineChart({
 		</ChartContainer>
 	);
 }
-
-type DotProps = ActiveDotProps & { warning: number; danger: number };
-
-const Dot = ({ cx, cy, value, warning, danger, isPeak }: DotProps & { isPeak?: boolean }) => {
-	let dangerLevel = getDangerLevel(value, warning, danger);
-
-	dangerLevel = normalizeDangerLevelForPeak(dangerLevel, isPeak);
-
-	const fillColor = dangerlevelStyles[dangerLevel].color;
-
-	return <circle cx={cx} cy={cy} r={6} fill={fillColor} />;
-};
 
 type CustomXAxisTickProps = XAxisTickContentProps & {
 	xMin: number;
@@ -279,74 +260,4 @@ function CustomXAxisTick({ x, y, xMin, xMax, payload, xTickLabels, formatTime, v
 			{label}
 		</text>
 	);
-}
-
-interface GradientStopsProps {
-	values: Array<number>;
-	warningThreshold: number;
-	dangerThreshold: number;
-	usePeakData?: boolean;
-}
-
-function GradientStops({ values, warningThreshold, dangerThreshold, usePeakData }: GradientStopsProps) {
-	const minValue = values.length > 0 ? Math.min(...values) : 0;
-	const maxValue = values.length > 0 ? Math.max(...values) : 0;
-
-	let minDangerLevel = getDangerLevel(minValue, warningThreshold, dangerThreshold);
-	let maxDangerLevel = getDangerLevel(maxValue, warningThreshold, dangerThreshold);
-
-	minDangerLevel = normalizeDangerLevelForPeak(minDangerLevel, usePeakData);
-	maxDangerLevel = normalizeDangerLevelForPeak(maxDangerLevel, usePeakData);
-
-	const uniformDangerLevel = minDangerLevel === maxDangerLevel ? minDangerLevel : undefined;
-
-	const getOffset = (y: number) => {
-		if (maxValue === minValue) {
-			return "0%";
-		}
-
-		return `${((maxValue - y) / (maxValue - minValue)) * 100}%`;
-	};
-
-	const dangerOffset = getOffset(dangerThreshold);
-	const warningOffset = getOffset(warningThreshold);
-
-	// If all values fall within the same danger level, use a solid color for the line instead of a gradient
-	if (uniformDangerLevel) {
-		const dangerLevelColor = dangerlevelStyles[uniformDangerLevel].color;
-		return (
-			<>
-				<stop offset="0%" stopColor={dangerLevelColor} />
-				<stop offset="100%" stopColor={dangerLevelColor} />
-			</>
-		);
-	}
-
-	return (
-		<>
-			<stop offset={dangerOffset} stopColor="var(--danger)" />
-
-			{/* Only show the warning gradient for non-peak data */}
-			{usePeakData ? (
-				<stop offset={dangerOffset} stopColor="var(--safe)" />
-			) : (
-				<>
-					<stop offset={dangerOffset} stopColor="var(--warning)" />
-					<stop offset={warningOffset} stopColor="var(--warning)" />
-					<stop offset={warningOffset} stopColor="var(--safe)" />
-				</>
-			)}
-
-			<stop offset="100%" stopColor="var(--safe)" />
-		</>
-	);
-}
-
-// Peak data doesn't have a warning danger level, so we treat warning levels as safe
-function normalizeDangerLevelForPeak(dangerLevel: DangerLevel, isPeak?: boolean): DangerLevel {
-	if (isPeak && dangerLevel === "warning") {
-		return "safe";
-	}
-
-	return dangerLevel;
 }

--- a/frontend/app/components/exposure-line-chart/sensor-legend.tsx
+++ b/frontend/app/components/exposure-line-chart/sensor-legend.tsx
@@ -1,0 +1,20 @@
+export type SensorLegendItem = {
+	label: string;
+	color: string;
+};
+
+export function SensorLegend({ items }: { items: Array<SensorLegendItem> }) {
+	return (
+		<div className="flex items-center gap-6 text-muted-foreground text-xs">
+			{items.map((item) => (
+				<div key={item.label} className="flex items-center gap-2">
+					<svg width="24" height="8" className="shrink-0" aria-label={item.label}>
+						<title>{item.label}</title>
+						<line x1="0" y1="4" x2="24" y2="4" stroke={item.color} strokeWidth="2" />
+					</svg>
+					<span>{item.label}</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
@@ -1,0 +1,268 @@
+import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import type { SensorDto, SensorTypeField } from "@/lib/dto";
+import type { Sensor, SensorUnit } from "@/lib/sensors";
+import { cn, formatSensorValue } from "@/lib/utils";
+import { addDays, addWeeks, endOfMonth, endOfWeek, getISOWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
+import type { CurveType } from "recharts/types/shape/Curve";
+
+type TrendGranularity = "day" | "week";
+
+export type TrendSeries = {
+	sensor: Sensor;
+	sensorField?: SensorTypeField;
+	data: Array<SensorDto>;
+};
+
+export interface TrendLineChartProps {
+	series: Array<TrendSeries>;
+	selectedDate: Date;
+	unit: SensorUnit;
+	minY: number;
+	maxY: number;
+	granularity: TrendGranularity;
+	lineType?: CurveType;
+	chartContainerClassName?: string;
+}
+
+type SeriesDefinition = {
+	dataKey: string;
+	label: string;
+	color: string;
+	valuesByBucket: Map<string, number>;
+};
+
+export function TrendLineChart({
+	series,
+	selectedDate,
+	unit,
+	minY,
+	maxY,
+	granularity,
+	lineType = "linear",
+	chartContainerClassName,
+}: TrendLineChartProps) {
+	const { t } = useTranslation();
+
+	const bucketDates = getBucketDates(selectedDate, granularity);
+	const seriesDefinitions = buildSeriesDefinitions(series, granularity);
+	const chartData = buildChartData(bucketDates, seriesDefinitions, granularity);
+
+	return (
+		<ChartContainer config={{}} className={cn("h-full w-full", chartContainerClassName)}>
+			<LineChart accessibilityLayer={true} data={chartData} margin={{ left: 12, right: 12 }}>
+				<CartesianGrid vertical={true} strokeDasharray="3 3" />
+
+				<XAxis
+					dataKey="label"
+					tickLine={false}
+					axisLine={false}
+					tickMargin={8}
+					tick={{
+						className: "text-sm",
+						fill: "var(--color-muted-foreground)",
+					}}
+				/>
+
+				<YAxis
+					tickLine={false}
+					axisLine={false}
+					tick={{
+						className: "text-base",
+						fill: "var(--color-muted-foreground)",
+					}}
+					domain={[minY, maxY]}
+					tickFormatter={(value) => formatSensorValue(value, unit, 0, { mg: 3 })}
+					label={{
+						value: t(($) => $.sensors.units[unit]),
+						position: "inside",
+						dx: -32,
+						angle: -90,
+						className: "text-lg mr-4",
+						fill: "var(--color-muted-foreground)",
+					}}
+				/>
+
+				<Tooltip unit={unit} seriesDefinitions={seriesDefinitions} />
+
+				{seriesDefinitions.map((serie) => (
+					<Line
+						key={serie.dataKey}
+						name={serie.label}
+						dataKey={serie.dataKey}
+						type={lineType}
+						stroke={serie.color}
+						strokeWidth="3"
+						isAnimationActive={false}
+						connectNulls={true}
+						dot={{
+							r: 3,
+							fill: serie.color,
+							stroke: serie.color,
+						}}
+						activeDot={{
+							r: 5,
+							fill: serie.color,
+							stroke: "none",
+						}}
+					/>
+				))}
+				<Legend wrapperStyle={{ paddingTop: 12 }} />
+			</LineChart>
+		</ChartContainer>
+	);
+}
+
+function buildSeriesDefinitions(series: Array<TrendSeries>, granularity: TrendGranularity): Array<SeriesDefinition> {
+	return series.map((serie) => ({
+		dataKey: getSeriesDataKey(serie.sensor, serie.sensorField),
+		label: getSeriesLabel(serie.sensor, serie.sensorField),
+		color: getSeriesColor(serie.sensor, serie.sensorField),
+		valuesByBucket: new Map(serie.data.map((item) => [normalizeBucketKey(item.time, granularity), item.value])),
+	}));
+}
+
+function buildChartData(
+	bucketDates: Array<Date>,
+	seriesDefinitions: Array<SeriesDefinition>,
+	granularity: TrendGranularity,
+): Array<Record<string, string | number | null>> {
+	return bucketDates.map((date) => {
+		const bucketKey = normalizeBucketKey(date, granularity);
+
+		const row: Record<string, string | number | null> = {
+			bucketKey,
+			label: granularity === "week" ? `W${getISOWeek(date)}` : formatDayLabel(date),
+		};
+
+		for (const serie of seriesDefinitions) {
+			row[serie.dataKey] = serie.valuesByBucket.get(bucketKey) ?? null;
+		}
+
+		return row;
+	});
+}
+
+function getSeriesDataKey(sensor: Sensor, field?: SensorTypeField): string {
+	return field ? `${sensor}:${field}` : sensor;
+}
+
+function getSeriesLabel(sensor: Sensor, field?: SensorTypeField): string {
+	const { t } = useTranslation();
+
+	if (!field) {
+		return t(($) => $.sensors[sensor]);
+	}
+
+	return t(($) => $.sensors.dustExposureLabels[field]);
+}
+
+function getSeriesColor(sensor: Sensor, field?: SensorTypeField): string {
+	const styleKey = field ? `${sensor}:${field}` : sensor;
+
+	switch (styleKey) {
+		case "dust:pm1_twa":
+			return "var(--color-green-700)";
+		case "dust:pm25_twa":
+			return "var(--color-blue-600)";
+		case "dust:pm10_twa":
+			return "var(--color-orange-400)";
+		case "noise":
+			return "var(--color-green-700)";
+		case "vibration":
+			return "var(--color-orange-500)";
+		default:
+			return "var(--color-blue-500)";
+	}
+}
+
+function getBucketDates(selectedDate: Date, granularity: TrendGranularity): Array<Date> {
+	const dates: Array<Date> = [];
+
+	if (granularity === "day") {
+		let current = startOfWeek(selectedDate, { weekStartsOn: 1 });
+		const end = endOfWeek(selectedDate, { weekStartsOn: 1 });
+
+		while (current <= end) {
+			dates.push(current);
+			current = addDays(current, 1);
+		}
+
+		return dates;
+	}
+
+	let current = startOfWeek(startOfMonth(selectedDate), { weekStartsOn: 1 });
+	const end = startOfWeek(endOfMonth(selectedDate), { weekStartsOn: 1 });
+
+	while (current <= end) {
+		dates.push(current);
+		current = addWeeks(current, 1);
+	}
+
+	return dates;
+}
+
+function normalizeBucketKey(date: Date, granularity: TrendGranularity): string {
+	if (granularity === "day") {
+		return startOfDay(date).toISOString();
+	}
+
+	return startOfWeek(date, { weekStartsOn: 1 }).toISOString();
+}
+
+// TODO: use date fns
+function formatDayLabel(date: Date): string {
+	const day = String(date.getDate()).padStart(2, "0");
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+
+	return `${day}.${month}`;
+}
+
+function Tooltip({ unit, seriesDefinitions }: { unit: SensorUnit; seriesDefinitions: Array<SeriesDefinition> }) {
+	const { t } = useTranslation();
+
+	return (
+		<ChartTooltip
+			cursor={false}
+			content={({ active, payload, label }) => {
+				if (!(active && payload?.length)) {
+					return null;
+				}
+
+				return (
+					<div className="rounded-md border bg-background p-3 shadow">
+						<div className="mb-2 font-medium">{label}</div>
+
+						<div className="space-y-1">
+							{payload.map((entry) => {
+								const series = seriesDefinitions.find(
+									(seriesDefinition) => seriesDefinition.dataKey === entry.dataKey,
+								);
+
+								return (
+									<div
+										key={String(entry.dataKey)}
+										className="flex items-center justify-between gap-4"
+									>
+										<div className="flex items-center gap-2">
+											<div
+												className="h-2 w-2 rounded-full"
+												style={{ backgroundColor: entry.color }}
+											/>
+											<span>{series?.label ?? entry.name}</span>
+										</div>
+
+										<span>
+											{formatSensorValue(entry.value, unit)} {t(($) => $.sensors.units[unit])}
+										</span>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				);
+			}}
+		/>
+	);
+}

--- a/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
@@ -1,9 +1,10 @@
 import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { useFormatDate } from "@/hooks/use-format-date";
+import { DangerLevels } from "@/lib/danger-levels";
 import type { SensorDto, SensorTypeField } from "@/lib/dto";
 import type { Sensor, SensorUnit } from "@/lib/sensors";
-import { cn, formatSensorValue } from "@/lib/utils";
-import { DangerLevels } from "@/lib/danger-levels";
 import { getThreshold } from "@/lib/thresholds";
+import { cn, formatSensorValue } from "@/lib/utils";
 import { addDays, addWeeks, endOfMonth, endOfWeek, getISOWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
 import { type JSX, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -56,10 +57,11 @@ export function TrendLineChart({
 	usePeakDangerThreshold = false,
 }: TrendLineChartProps) {
 	const { t } = useTranslation();
+	const formatDate = useFormatDate();
 
 	const bucketDates = getBucketDates(selectedDate, granularity);
 	const seriesDefinitions = buildSeriesDefinitions(series, granularity, t);
-	const chartData = buildChartData(bucketDates, seriesDefinitions, granularity);
+	const chartData = buildChartData(bucketDates, seriesDefinitions, granularity, formatDate, t);
 
 	const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
 
@@ -221,13 +223,15 @@ function buildChartData(
 	bucketDates: Array<Date>,
 	seriesDefinitions: Array<SeriesDefinition>,
 	granularity: TrendGranularity,
+	formatDate: ReturnType<typeof useFormatDate>,
+	t: ReturnType<typeof useTranslation>["t"],
 ): Array<Record<string, string | number | null>> {
 	return bucketDates.map((date) => {
 		const bucketKey = normalizeBucketKey(date, granularity);
 
 		const row: Record<string, string | number | null> = {
 			bucketKey,
-			label: granularity === "week" ? `W${getISOWeek(date)}` : formatDayLabel(date),
+			label: getBucketLabel(date, granularity, t, formatDate),
 		};
 
 		for (const serie of seriesDefinitions) {
@@ -236,6 +240,21 @@ function buildChartData(
 
 		return row;
 	});
+}
+
+function getBucketLabel(
+	date: Date,
+	granularity: TrendGranularity,
+	t: ReturnType<typeof useTranslation>["t"],
+	formatDate: ReturnType<typeof useFormatDate>,
+): string {
+	if (granularity === "week") {
+		return t(($) => $.common.weekNumber, {
+			week: getISOWeek(date),
+		});
+	}
+
+	return formatDate(date, "dd.MM");
 }
 
 function getSeriesDataKey(sensor: Sensor, field?: SensorTypeField): string {
@@ -305,14 +324,6 @@ function normalizeBucketKey(date: Date, granularity: TrendGranularity): string {
 	}
 
 	return startOfWeek(date, { weekStartsOn: 1 }).toISOString();
-}
-
-// TODO: use date fns
-function formatDayLabel(date: Date): string {
-	const day = String(date.getDate()).padStart(2, "0");
-	const month = String(date.getMonth() + 1).padStart(2, "0");
-
-	return `${day}.${month}`;
 }
 
 function Tooltip({ unit, seriesDefinitions }: { unit: SensorUnit; seriesDefinitions: Array<SeriesDefinition> }) {

--- a/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-line-chart/trend-line-chart.tsx
@@ -2,12 +2,20 @@ import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
 import type { SensorDto, SensorTypeField } from "@/lib/dto";
 import type { Sensor, SensorUnit } from "@/lib/sensors";
 import { cn, formatSensorValue } from "@/lib/utils";
+import { DangerLevels } from "@/lib/danger-levels";
+import { getThreshold } from "@/lib/thresholds";
 import { addDays, addWeeks, endOfMonth, endOfWeek, getISOWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
+import { type JSX, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
 import type { CurveType } from "recharts/types/shape/Curve";
+import { SensorLegend } from "./sensor-legend";
+import { ThresholdLegend } from "./threshold-legend";
+import { ThresholdLine } from "./threshold-line";
 
 type TrendGranularity = "day" | "week";
+
+const Y_AXIS_WIDTH = 60;
 
 export type TrendSeries = {
 	sensor: Sensor;
@@ -24,9 +32,12 @@ export interface TrendLineChartProps {
 	granularity: TrendGranularity;
 	lineType?: CurveType;
 	chartContainerClassName?: string;
+	usePeakDangerThreshold?: boolean;
 }
 
 type SeriesDefinition = {
+	sensor: Sensor;
+	sensorField?: SensorTypeField;
 	dataKey: string;
 	label: string;
 	color: string;
@@ -42,12 +53,19 @@ export function TrendLineChart({
 	granularity,
 	lineType = "linear",
 	chartContainerClassName,
+	usePeakDangerThreshold = false,
 }: TrendLineChartProps) {
 	const { t } = useTranslation();
 
 	const bucketDates = getBucketDates(selectedDate, granularity);
-	const seriesDefinitions = buildSeriesDefinitions(series, granularity);
+	const seriesDefinitions = buildSeriesDefinitions(series, granularity, t);
 	const chartData = buildChartData(bucketDates, seriesDefinitions, granularity);
+
+	const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
+
+	const isSingleSeries = seriesDefinitions.length === 1;
+
+	const activeSeriesKey = isSingleSeries ? (seriesDefinitions[0]?.dataKey ?? null) : hoveredSeriesKey;
 
 	return (
 		<ChartContainer config={{}} className={cn("h-full w-full", chartContainerClassName)}>
@@ -66,6 +84,7 @@ export function TrendLineChart({
 				/>
 
 				<YAxis
+					width={Y_AXIS_WIDTH}
 					tickLine={false}
 					axisLine={false}
 					tick={{
@@ -96,6 +115,9 @@ export function TrendLineChart({
 						strokeWidth="3"
 						isAnimationActive={false}
 						connectNulls={true}
+						onMouseEnter={() => setHoveredSeriesKey(serie.dataKey)}
+						onMouseLeave={() => setHoveredSeriesKey(null)}
+						opacity={hoveredSeriesKey !== null && hoveredSeriesKey !== serie.dataKey ? 0.5 : 1}
 						dot={{
 							r: 3,
 							fill: serie.color,
@@ -108,16 +130,88 @@ export function TrendLineChart({
 						}}
 					/>
 				))}
-				<Legend wrapperStyle={{ paddingTop: 12 }} />
+
+				{seriesDefinitions.map((serie) => {
+					if (activeSeriesKey !== serie.dataKey) {
+						return null;
+					}
+
+					const threshold = getThreshold(serie.sensor, serie.sensorField);
+
+					const thresholdLines: Array<JSX.Element> = [];
+
+					if (threshold.peakDanger && usePeakDangerThreshold) {
+						thresholdLines.push(
+							<ThresholdLine
+								key={`${serie.dataKey}-danger`}
+								y={threshold.peakDanger}
+								dangerLevel="danger"
+							/>,
+						);
+					} else {
+						if (threshold.warning) {
+							thresholdLines.push(
+								<ThresholdLine
+									key={`${serie.dataKey}-warning`}
+									y={threshold.warning}
+									dangerLevel="warning"
+								/>,
+							);
+						}
+
+						if (threshold.danger) {
+							thresholdLines.push(
+								<ThresholdLine
+									key={`${serie.dataKey}-danger`}
+									y={threshold.danger}
+									dangerLevel="danger"
+								/>,
+							);
+						}
+					}
+
+					return thresholdLines;
+				})}
+
+				<Legend
+					content={() => (
+						<div className="mt-2 flex flex-col gap-3" style={{ marginLeft: Y_AXIS_WIDTH }}>
+							<SensorLegend
+								items={seriesDefinitions.map((serie) => ({
+									label: getSeriesLabel(serie.sensor, serie.sensorField, t),
+									color: serie.color,
+								}))}
+							/>
+							<ThresholdLegend
+								items={[
+									{
+										dangerLevel: "danger",
+										color: `var(--${DangerLevels.danger.color})`,
+									},
+									{
+										dangerLevel: "warning",
+										color: `var(--${DangerLevels.warning.color})`,
+									},
+								]}
+							/>
+						</div>
+					)}
+				/>
 			</LineChart>
 		</ChartContainer>
 	);
 }
 
-function buildSeriesDefinitions(series: Array<TrendSeries>, granularity: TrendGranularity): Array<SeriesDefinition> {
+function buildSeriesDefinitions(
+	series: Array<TrendSeries>,
+	granularity: TrendGranularity,
+	t: ReturnType<typeof useTranslation>["t"],
+): Array<SeriesDefinition> {
 	return series.map((serie) => ({
+		sensor: serie.sensor,
+		sensorField: serie.sensorField,
 		dataKey: getSeriesDataKey(serie.sensor, serie.sensorField),
-		label: getSeriesLabel(serie.sensor, serie.sensorField),
+		label: getSeriesLabel(serie.sensor, serie.sensorField, t),
 		color: getSeriesColor(serie.sensor, serie.sensorField),
 		valuesByBucket: new Map(serie.data.map((item) => [normalizeBucketKey(item.time, granularity), item.value])),
 	}));
@@ -148,9 +242,11 @@ function getSeriesDataKey(sensor: Sensor, field?: SensorTypeField): string {
 	return field ? `${sensor}:${field}` : sensor;
 }
 
-function getSeriesLabel(sensor: Sensor, field?: SensorTypeField): string {
-	const { t } = useTranslation();
-
+function getSeriesLabel(
+	sensor: Sensor,
+	field: SensorTypeField | undefined,
+	t: ReturnType<typeof useTranslation>["t"],
+): string {
 	if (!field) {
 		return t(($) => $.sensors[sensor]);
 	}
@@ -159,22 +255,22 @@ function getSeriesLabel(sensor: Sensor, field?: SensorTypeField): string {
 }
 
 function getSeriesColor(sensor: Sensor, field?: SensorTypeField): string {
-	const styleKey = field ? `${sensor}:${field}` : sensor;
-
-	switch (styleKey) {
-		case "dust:pm1_twa":
-			return "var(--color-green-700)";
-		case "dust:pm25_twa":
-			return "var(--color-blue-600)";
-		case "dust:pm10_twa":
-			return "var(--color-orange-400)";
-		case "noise":
-			return "var(--color-green-700)";
-		case "vibration":
-			return "var(--color-orange-500)";
-		default:
-			return "var(--color-blue-500)";
+	if (sensor === "dust") {
+		switch (field) {
+			case "pm1_twa":
+				return "var(--color-green-700)";
+			case "pm25_twa":
+				return "var(--color-blue-600)";
+			case "pm4_twa":
+				return "var(--color-orange-400)";
+			case "pm10_twa":
+				return "var(--color-red-600)";
+			default:
+				return "var(--color-blue-600)";
+		}
 	}
+
+	return "var(--color-green-700)";
 }
 
 function getBucketDates(selectedDate: Date, granularity: TrendGranularity): Array<Date> {

--- a/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
@@ -37,10 +37,12 @@ export function ExposureTrendTooltip({
 										className="flex items-center justify-between gap-4"
 									>
 										<div className="flex items-center gap-2">
-											<div
-												className="h-2 w-2 rounded-full"
-												style={{ backgroundColor: entry.color }}
-											/>
+											{seriesDefinitions.length > 1 && (
+												<div
+													className="h-2 w-2 rounded-full"
+													style={{ backgroundColor: entry.color }}
+												/>
+											)}
 											<span>{series?.label ?? entry.name}</span>
 										</div>
 

--- a/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
@@ -1,0 +1,59 @@
+import type { SensorUnit } from "@/lib/sensors";
+import { formatSensorValue } from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+import { ChartTooltip } from "../ui/chart";
+import type { SeriesDefinition } from "./trend-line-chart";
+
+export function ExposureTrendTooltip({
+	unit,
+	seriesDefinitions,
+}: {
+	unit: SensorUnit;
+	seriesDefinitions: Array<SeriesDefinition>;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<ChartTooltip
+			cursor={false}
+			content={({ active, payload, label }) => {
+				if (!(active && payload?.length)) {
+					return null;
+				}
+
+				return (
+					<div className="rounded-md border bg-background p-3 shadow">
+						<div className="mb-2 font-medium">{label}</div>
+
+						<div className="space-y-1">
+							{payload.map((entry) => {
+								const series = seriesDefinitions.find(
+									(seriesDefinition) => seriesDefinition.dataKey === entry.dataKey,
+								);
+
+								return (
+									<div
+										key={String(entry.dataKey)}
+										className="flex items-center justify-between gap-4"
+									>
+										<div className="flex items-center gap-2">
+											<div
+												className="h-2 w-2 rounded-full"
+												style={{ backgroundColor: entry.color }}
+											/>
+											<span>{series?.label ?? entry.name}</span>
+										</div>
+
+										<span>
+											{formatSensorValue(entry.value, unit)} {t(($) => $.sensors.units[unit])}
+										</span>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				);
+			}}
+		/>
+	);
+}

--- a/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
@@ -96,6 +96,12 @@ export function TrendLineChart({
 		singleSeriesValues = Array.from(singleSeries.valuesByBucket.values());
 	}
 
+	const dataBucketCount = chartData.filter((row) =>
+		seriesDefinitions.some((serie) => row[serie.dataKey] != null),
+	).length;
+
+	const showDot = dataBucketCount === 1;
+
 	return (
 		<ChartContainer config={{}} className={cn("h-full w-full", chartContainerClassName)}>
 			<LineChart accessibilityLayer={true} data={chartData} margin={{ left: 12, right: 12 }}>
@@ -160,7 +166,7 @@ export function TrendLineChart({
 						onMouseEnter={() => setHoveredSeriesKey(serie.dataKey)}
 						onMouseLeave={() => setHoveredSeriesKey(null)}
 						opacity={hoveredSeriesKey !== null && hoveredSeriesKey !== serie.dataKey ? 0.5 : 1}
-						dot={false}
+						dot={showDot}
 						activeDot={
 							isSingleSeries && singleSeriesDangerThreshold !== null
 								? (props) => (

--- a/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
@@ -6,10 +6,12 @@ import type { Sensor, SensorUnit } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { cn, formatSensorValue } from "@/lib/utils";
 import { addDays, addWeeks, endOfMonth, endOfWeek, getISOWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
 import type { CurveType } from "recharts/types/shape/Curve";
+import { ExposureDot } from "../exposure-line-chart/exposure-dot";
+import { ExposureLineChartGradientStops } from "../exposure-line-chart/exposure-line-chart-gradient-stops";
 import { SensorLegend } from "../exposure-line-chart/sensor-legend";
 import { ThresholdLegend } from "../exposure-line-chart/threshold-legend";
 import { ThresholdLine } from "../exposure-line-chart/threshold-line";
@@ -42,7 +44,6 @@ export type SeriesDefinition = {
 	sensorField?: SensorTypeField;
 	dataKey: string;
 	label: string;
-	color: string;
 	valuesByBucket: Map<string, number>;
 };
 
@@ -59,6 +60,7 @@ export function TrendLineChart({
 }: TrendLineChartProps) {
 	const { t } = useTranslation();
 	const formatDate = useFormatDate();
+	const gradientId = useId();
 
 	const bucketDates = getBucketDates(selectedDate, granularity);
 	const seriesDefinitions = buildSeriesDefinitions(series, granularity, t);
@@ -74,6 +76,25 @@ export function TrendLineChart({
 	const activeSeries = seriesDefinitions.find((serie) => serie.dataKey === activeSeriesKey) ?? null;
 
 	const thresholdLines = activeSeries ? getThresholdLines(activeSeries, usePeakDangerThreshold) : [];
+
+	const singleSeries = isSingleSeries ? (seriesDefinitions[0] ?? null) : null;
+
+	let singleSeriesThreshold: ReturnType<typeof getThreshold> | null = null;
+	let singleSeriesDangerThreshold: number | null = null;
+	let singleSeriesWarningThreshold = 0;
+	let singleSeriesValues: Array<number> = [];
+
+	if (singleSeries) {
+		singleSeriesThreshold = getThreshold(singleSeries.sensor, singleSeries.sensorField);
+
+		singleSeriesDangerThreshold = usePeakDangerThreshold
+			? singleSeriesThreshold.peakDanger
+			: singleSeriesThreshold.danger;
+
+		singleSeriesWarningThreshold = singleSeriesThreshold.warning;
+
+		singleSeriesValues = Array.from(singleSeries.valuesByBucket.values());
+	}
 
 	return (
 		<ChartContainer config={{}} className={cn("h-full w-full", chartContainerClassName)}>
@@ -113,32 +134,51 @@ export function TrendLineChart({
 
 				<ExposureTrendTooltip unit={unit} seriesDefinitions={seriesDefinitions} />
 
+				{isSingleSeries && singleSeriesThreshold && singleSeriesDangerThreshold && (
+					<defs>
+						<linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+							<ExposureLineChartGradientStops
+								values={singleSeriesValues}
+								warningThreshold={singleSeriesWarningThreshold}
+								dangerThreshold={singleSeriesDangerThreshold}
+								usePeakData={usePeakDangerThreshold}
+							/>
+						</linearGradient>
+					</defs>
+				)}
+
 				{seriesDefinitions.map((serie) => (
 					<Line
 						key={serie.dataKey}
 						name={serie.label}
 						dataKey={serie.dataKey}
 						type={lineType}
-						stroke={serie.color}
-						strokeWidth="3"
+						stroke={isSingleSeries ? `url(#${gradientId})` : getDustFieldColor(serie.sensorField)}
+						strokeWidth={3}
 						isAnimationActive={false}
 						connectNulls={true}
 						onMouseEnter={() => setHoveredSeriesKey(serie.dataKey)}
 						onMouseLeave={() => setHoveredSeriesKey(null)}
 						opacity={hoveredSeriesKey !== null && hoveredSeriesKey !== serie.dataKey ? 0.5 : 1}
-						dot={{
-							r: 3,
-							fill: serie.color,
-							stroke: serie.color,
-						}}
-						activeDot={{
-							r: 5,
-							fill: serie.color,
-							stroke: "none",
-						}}
+						dot={false}
+						activeDot={
+							isSingleSeries && singleSeriesDangerThreshold !== null
+								? (props) => (
+										<ExposureDot
+											{...props}
+											warning={singleSeriesWarningThreshold}
+											danger={singleSeriesDangerThreshold}
+											isPeak={usePeakDangerThreshold}
+										/>
+									)
+								: {
+										r: 5,
+										fill: getDustFieldColor(serie.sensorField),
+										stroke: "none",
+									}
+						}
 					/>
 				))}
-
 				{thresholdLines.map((line) => (
 					<ThresholdLine key={line.key} y={line.y} dangerLevel={line.dangerLevel} />
 				))}
@@ -151,7 +191,7 @@ export function TrendLineChart({
 								<SensorLegend
 									items={seriesDefinitions.map((serie) => ({
 										label: getSeriesLabel(serie.sensor, serie.sensorField, t),
-										color: serie.color,
+										color: getDustFieldColor(serie.sensorField),
 									}))}
 								/>
 							)}
@@ -224,7 +264,6 @@ function buildSeriesDefinitions(
 		sensorField: serie.sensorField,
 		dataKey: getSeriesDataKey(serie.sensor, serie.sensorField),
 		label: getSeriesLabel(serie.sensor, serie.sensorField, t),
-		color: getSeriesColor(serie.sensor, serie.sensorField),
 		valuesByBucket: new Map(serie.data.map((item) => [normalizeBucketKey(item.time, granularity), item.value])),
 	}));
 }
@@ -283,23 +322,19 @@ function getSeriesLabel(
 	return t(($) => $.sensors.dustExposureLabels[field]);
 }
 
-function getSeriesColor(sensor: Sensor, field?: SensorTypeField): string {
-	if (sensor === "dust") {
-		switch (field) {
-			case "pm1_twa":
-				return "var(--color-green-700)";
-			case "pm25_twa":
-				return "var(--color-blue-600)";
-			case "pm4_twa":
-				return "var(--color-orange-400)";
-			case "pm10_twa":
-				return "var(--color-red-600)";
-			default:
-				return "var(--color-blue-600)";
-		}
+function getDustFieldColor(field?: SensorTypeField): string {
+	switch (field) {
+		case "pm1_twa":
+			return "var(--color-green-700)";
+		case "pm25_twa":
+			return "var(--color-blue-600)";
+		case "pm4_twa":
+			return "var(--color-orange-400)";
+		case "pm10_twa":
+			return "var(--color-red-600)";
+		default:
+			return "var(--color-blue-600)";
 	}
-
-	return "var(--color-green-700)";
 }
 
 /**

--- a/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
@@ -146,12 +146,15 @@ export function TrendLineChart({
 				<Legend
 					content={() => (
 						<div className="mt-2 flex flex-col gap-3" style={{ marginLeft: Y_AXIS_WIDTH }}>
-							<SensorLegend
-								items={seriesDefinitions.map((serie) => ({
-									label: getSeriesLabel(serie.sensor, serie.sensorField, t),
-									color: serie.color,
-								}))}
-							/>
+							{/* Only show sensor legend if there are multiple sensors or fields */}
+							{!isSingleSeries && (
+								<SensorLegend
+									items={seriesDefinitions.map((serie) => ({
+										label: getSeriesLabel(serie.sensor, serie.sensorField, t),
+										color: serie.color,
+									}))}
+								/>
+							)}
 							<ThresholdLegend
 								items={[
 									{

--- a/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/trend-line-chart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { ChartContainer } from "@/components/ui/chart";
 import { useFormatDate } from "@/hooks/use-format-date";
 import { DangerLevels } from "@/lib/danger-levels";
 import type { SensorDto, SensorTypeField } from "@/lib/dto";
@@ -6,13 +6,14 @@ import type { Sensor, SensorUnit } from "@/lib/sensors";
 import { getThreshold } from "@/lib/thresholds";
 import { cn, formatSensorValue } from "@/lib/utils";
 import { addDays, addWeeks, endOfMonth, endOfWeek, getISOWeek, startOfDay, startOfMonth, startOfWeek } from "date-fns";
-import { type JSX, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
 import type { CurveType } from "recharts/types/shape/Curve";
-import { SensorLegend } from "./sensor-legend";
-import { ThresholdLegend } from "./threshold-legend";
-import { ThresholdLine } from "./threshold-line";
+import { SensorLegend } from "../exposure-line-chart/sensor-legend";
+import { ThresholdLegend } from "../exposure-line-chart/threshold-legend";
+import { ThresholdLine } from "../exposure-line-chart/threshold-line";
+import { ExposureTrendTooltip } from "./exposure-trend-tooltip";
 
 type TrendGranularity = "day" | "week";
 
@@ -36,7 +37,7 @@ export interface TrendLineChartProps {
 	usePeakDangerThreshold?: boolean;
 }
 
-type SeriesDefinition = {
+export type SeriesDefinition = {
 	sensor: Sensor;
 	sensorField?: SensorTypeField;
 	dataKey: string;
@@ -67,7 +68,12 @@ export function TrendLineChart({
 
 	const isSingleSeries = seriesDefinitions.length === 1;
 
+	// If we only have 1 series, we always show the thresholds for that series, otherwise we only show the thresholds for the hovered series
 	const activeSeriesKey = isSingleSeries ? (seriesDefinitions[0]?.dataKey ?? null) : hoveredSeriesKey;
+
+	const activeSeries = seriesDefinitions.find((serie) => serie.dataKey === activeSeriesKey) ?? null;
+
+	const thresholdLines = activeSeries ? getThresholdLines(activeSeries, usePeakDangerThreshold) : [];
 
 	return (
 		<ChartContainer config={{}} className={cn("h-full w-full", chartContainerClassName)}>
@@ -105,7 +111,7 @@ export function TrendLineChart({
 					}}
 				/>
 
-				<Tooltip unit={unit} seriesDefinitions={seriesDefinitions} />
+				<ExposureTrendTooltip unit={unit} seriesDefinitions={seriesDefinitions} />
 
 				{seriesDefinitions.map((serie) => (
 					<Line
@@ -133,47 +139,9 @@ export function TrendLineChart({
 					/>
 				))}
 
-				{seriesDefinitions.map((serie) => {
-					if (activeSeriesKey !== serie.dataKey) {
-						return null;
-					}
-
-					const threshold = getThreshold(serie.sensor, serie.sensorField);
-
-					const thresholdLines: Array<JSX.Element> = [];
-
-					if (threshold.peakDanger && usePeakDangerThreshold) {
-						thresholdLines.push(
-							<ThresholdLine
-								key={`${serie.dataKey}-danger`}
-								y={threshold.peakDanger}
-								dangerLevel="danger"
-							/>,
-						);
-					} else {
-						if (threshold.warning) {
-							thresholdLines.push(
-								<ThresholdLine
-									key={`${serie.dataKey}-warning`}
-									y={threshold.warning}
-									dangerLevel="warning"
-								/>,
-							);
-						}
-
-						if (threshold.danger) {
-							thresholdLines.push(
-								<ThresholdLine
-									key={`${serie.dataKey}-danger`}
-									y={threshold.danger}
-									dangerLevel="danger"
-								/>,
-							);
-						}
-					}
-
-					return thresholdLines;
-				})}
+				{thresholdLines.map((line) => (
+					<ThresholdLine key={line.key} y={line.y} dangerLevel={line.dangerLevel} />
+				))}
 
 				<Legend
 					content={() => (
@@ -202,6 +170,45 @@ export function TrendLineChart({
 			</LineChart>
 		</ChartContainer>
 	);
+}
+
+function getThresholdLines(
+	serie: SeriesDefinition,
+	usePeakDangerThreshold: boolean,
+): Array<{ key: string; y: number; dangerLevel: "warning" | "danger" }> {
+	const threshold = getThreshold(serie.sensor, serie.sensorField);
+	const lines: Array<{
+		key: string;
+		y: number;
+		dangerLevel: "warning" | "danger";
+	}> = [];
+
+	if (threshold.peakDanger && usePeakDangerThreshold) {
+		lines.push({
+			key: `${serie.dataKey}-danger`,
+			y: threshold.peakDanger,
+			dangerLevel: "danger",
+		});
+		return lines;
+	}
+
+	if (threshold.warning) {
+		lines.push({
+			key: `${serie.dataKey}-warning`,
+			y: threshold.warning,
+			dangerLevel: "warning",
+		});
+	}
+
+	if (threshold.danger) {
+		lines.push({
+			key: `${serie.dataKey}-danger`,
+			y: threshold.danger,
+			dangerLevel: "danger",
+		});
+	}
+
+	return lines;
 }
 
 function buildSeriesDefinitions(
@@ -292,6 +299,11 @@ function getSeriesColor(sensor: Sensor, field?: SensorTypeField): string {
 	return "var(--color-green-700)";
 }
 
+/**
+ * Creates one bucket for every day of the week for granularity week,
+ * or every week of the month for granularity month,
+ * for the given data.
+ */
 function getBucketDates(selectedDate: Date, granularity: TrendGranularity): Array<Date> {
 	const dates: Array<Date> = [];
 
@@ -324,52 +336,4 @@ function normalizeBucketKey(date: Date, granularity: TrendGranularity): string {
 	}
 
 	return startOfWeek(date, { weekStartsOn: 1 }).toISOString();
-}
-
-function Tooltip({ unit, seriesDefinitions }: { unit: SensorUnit; seriesDefinitions: Array<SeriesDefinition> }) {
-	const { t } = useTranslation();
-
-	return (
-		<ChartTooltip
-			cursor={false}
-			content={({ active, payload, label }) => {
-				if (!(active && payload?.length)) {
-					return null;
-				}
-
-				return (
-					<div className="rounded-md border bg-background p-3 shadow">
-						<div className="mb-2 font-medium">{label}</div>
-
-						<div className="space-y-1">
-							{payload.map((entry) => {
-								const series = seriesDefinitions.find(
-									(seriesDefinition) => seriesDefinition.dataKey === entry.dataKey,
-								);
-
-								return (
-									<div
-										key={String(entry.dataKey)}
-										className="flex items-center justify-between gap-4"
-									>
-										<div className="flex items-center gap-2">
-											<div
-												className="h-2 w-2 rounded-full"
-												style={{ backgroundColor: entry.color }}
-											/>
-											<span>{series?.label ?? entry.name}</span>
-										</div>
-
-										<span>
-											{formatSensorValue(entry.value, unit)} {t(($) => $.sensors.units[unit])}
-										</span>
-									</div>
-								);
-							})}
-						</div>
-					</div>
-				);
-			}}
-		/>
-	);
 }

--- a/frontend/app/features/trend-line-chart-card/base-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/base-trend-line-chart-card.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PropsWithChildren } from "react";
+import { useTranslation } from "react-i18next";
+import { useView } from "../views/use-view";
+
+export function BaseTrendLineChartCard({ children }: PropsWithChildren) {
+	const { view } = useView();
+	const { t } = useTranslation();
+
+	return (
+		<Card className="max-w-xl">
+			<CardHeader>
+				<CardTitle>
+					{t(($) => $.exposureTrendLineChartCard.title, {
+						view: t(($) => $.views[view]).toLowerCase(),
+					})}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>{children}</CardContent>
+		</Card>
+	);
+}

--- a/frontend/app/features/trend-line-chart-card/base-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/base-trend-line-chart-card.tsx
@@ -8,7 +8,7 @@ export function BaseTrendLineChartCard({ children }: PropsWithChildren) {
 	const { t } = useTranslation();
 
 	return (
-		<Card className="max-w-xl">
+		<Card className="max-w-lg">
 			<CardHeader>
 				<CardTitle>
 					{t(($) => $.exposureTrendLineChartCard.title, {

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -1,0 +1,110 @@
+import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { sensorQueryOptions } from "@/lib/api";
+import { buildSensorQuery } from "@/lib/sensor-query-utils";
+import type { SensorUnit } from "@/lib/sensors";
+import { computeYAxisRange } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { useDate } from "../date-picker/use-date";
+import { useUser } from "../user/user-context";
+import { useView } from "../views/use-view";
+
+interface Props {
+	unit: SensorUnit;
+}
+
+export function DustTrendLineChartCard({ unit }: Props) {
+	const { date } = useDate();
+	const { view } = useView();
+	const { user } = useUser();
+
+	const sensor = "dust";
+
+	const { data: maxPm1Result } = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query: buildSensorQuery(sensor, view, date, {
+				field: "pm1_twa",
+				aggregationFunction: "max",
+				granularity: "day",
+			}),
+			userId: user.id,
+			enabled: view !== "day",
+		}),
+	);
+
+	const { data: maxPm25Result } = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query: buildSensorQuery(sensor, view, date, {
+				field: "pm25_twa",
+				aggregationFunction: "max",
+				granularity: "day",
+			}),
+			userId: user.id,
+			enabled: view !== "day",
+		}),
+	);
+
+	const { data: maxPm10Result } = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query: buildSensorQuery(sensor, view, date, {
+				field: "pm10_twa",
+				aggregationFunction: "max",
+				granularity: "day",
+			}),
+			userId: user.id,
+			enabled: view !== "day",
+		}),
+	);
+
+	const maxPm1Data = maxPm1Result?.data ?? [];
+	const maxPm25Data = maxPm25Result?.data ?? [];
+	const maxPm10Data = maxPm10Result?.data ?? [];
+
+	const allData = [...maxPm1Data, ...maxPm25Data, ...maxPm10Data];
+
+	const maxValue = Math.max(...allData.map((d) => d.value));
+
+	// TODO: we should compute maxY from sensor in a utils that also has the default maxY for every sensor
+	const minY = 0;
+	const baseMaxY = 45;
+	const maxY = maxValue > baseMaxY ? computeYAxisRange(allData).maxY : baseMaxY;
+
+	const granularity = view === "week" ? "day" : "week";
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Trend</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<TrendLineChart
+					selectedDate={date}
+					granularity={granularity}
+					unit={unit}
+					minY={minY}
+					maxY={maxY}
+					series={[
+						{
+							data: maxPm1Result?.data ?? [],
+							sensor,
+							sensorField: "pm1_twa",
+						},
+						{
+							data: maxPm25Result?.data ?? [],
+							sensor,
+							sensorField: "pm25_twa",
+						},
+						{
+							data: maxPm10Result?.data ?? [],
+							sensor,
+							sensorField: "pm10_twa",
+						},
+					]}
+				/>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -33,7 +33,21 @@ export function DustTrendLineChartCard({ unit }: Props) {
 		}),
 	);
 
+	const { data: maxPm4Result } = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query: buildSensorQuery(sensor, view, date, {
+				field: "pm4_twa",
+				aggregationFunction: "max",
+				granularity: "day",
+			}),
+			userId: user.id,
+			enabled: view !== "day",
+		}),
+	);
+
 	const { data: maxPm25Result } = useQuery(
+		//TODO: Switch 2500 instead of 25, same for the other ones
 		sensorQueryOptions({
 			sensor,
 			query: buildSensorQuery(sensor, view, date, {
@@ -91,6 +105,11 @@ export function DustTrendLineChartCard({ unit }: Props) {
 							data: maxPm1Result?.data ?? [],
 							sensor,
 							sensorField: "pm1_twa",
+						},
+						{
+							data: maxPm4Result?.data ?? [],
+							sensor,
+							sensorField: "pm4_twa",
 						},
 						{
 							data: maxPm25Result?.data ?? [],

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -13,9 +13,10 @@ import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
 	unit: SensorUnit;
+	userId?: string;
 }
 
-export function DustTrendLineChartCard({ unit }: Props) {
+export function DustTrendLineChartCard({ unit, userId }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
@@ -35,7 +36,7 @@ export function DustTrendLineChartCard({ unit }: Props) {
 				aggregationFunction: "max",
 				granularity: "day",
 			}),
-			userId: user.id,
+			userId: userId ?? user.id,
 			enabled: queriesEnabled,
 		}),
 	);

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -1,14 +1,16 @@
 import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
+import type { SensorTypeField } from "@/lib/dto";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { SensorUnit } from "@/lib/sensors";
 import { computeYAxisRange } from "@/lib/utils";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
 	unit: SensorUnit;
@@ -22,64 +24,39 @@ export function DustTrendLineChartCard({ unit }: Props) {
 
 	const sensor = "dust";
 
-	const { data: maxPm1Result } = useQuery(
+	//TODO: Switch 2500 instead of 25, same for the other ones
+	const dustFieldsToQuery: Array<SensorTypeField> = ["pm1_twa", "pm4_twa", "pm25_twa", "pm10_twa"];
+
+	const queriesEnabled = view !== "day";
+
+	const queryOptions = dustFieldsToQuery.map((field) =>
 		sensorQueryOptions({
 			sensor,
 			query: buildSensorQuery(sensor, view, date, {
-				field: "pm1_twa",
+				field,
 				aggregationFunction: "max",
 				granularity: "day",
 			}),
 			userId: user.id,
-			enabled: view !== "day",
+			enabled: queriesEnabled,
 		}),
 	);
 
-	const { data: maxPm4Result } = useQuery(
-		sensorQueryOptions({
-			sensor,
-			query: buildSensorQuery(sensor, view, date, {
-				field: "pm4_twa",
-				aggregationFunction: "max",
-				granularity: "day",
-			}),
-			userId: user.id,
-			enabled: view !== "day",
-		}),
-	);
+	const queryResults = useQueries({ queries: queryOptions });
 
-	const { data: maxPm25Result } = useQuery(
-		//TODO: Switch 2500 instead of 25, same for the other ones
-		sensorQueryOptions({
-			sensor,
-			query: buildSensorQuery(sensor, view, date, {
-				field: "pm25_twa",
-				aggregationFunction: "max",
-				granularity: "day",
-			}),
-			userId: user.id,
-			enabled: view !== "day",
-		}),
-	);
+	const maxPm1Data = queryResults[0]?.data?.data ?? [];
+	const maxPm4Data = queryResults[1]?.data?.data ?? [];
+	const maxPm25Data = queryResults[2]?.data?.data ?? [];
+	const maxPm10Data = queryResults[3]?.data?.data ?? [];
 
-	const { data: maxPm10Result } = useQuery(
-		sensorQueryOptions({
-			sensor,
-			query: buildSensorQuery(sensor, view, date, {
-				field: "pm10_twa",
-				aggregationFunction: "max",
-				granularity: "day",
-			}),
-			userId: user.id,
-			enabled: view !== "day",
-		}),
-	);
+	const granularity = view === "week" ? "day" : "week";
 
-	const maxPm1Data = maxPm1Result?.data ?? [];
-	const maxPm25Data = maxPm25Result?.data ?? [];
-	const maxPm10Data = maxPm10Result?.data ?? [];
+	const pm1Data = granularity === "week" ? toWeeklyMax(maxPm1Data) : maxPm1Data;
+	const pm4Data = granularity === "week" ? toWeeklyMax(maxPm4Data) : maxPm4Data;
+	const pm25Data = granularity === "week" ? toWeeklyMax(maxPm25Data) : maxPm25Data;
+	const pm10Data = granularity === "week" ? toWeeklyMax(maxPm10Data) : maxPm10Data;
 
-	const allData = [...maxPm1Data, ...maxPm25Data, ...maxPm10Data];
+	const allData = [...pm1Data, ...pm4Data, ...pm25Data, ...pm10Data];
 
 	const maxValue = Math.max(...allData.map((d) => d.value));
 
@@ -88,13 +65,13 @@ export function DustTrendLineChartCard({ unit }: Props) {
 	const baseMaxY = 45;
 	const maxY = maxValue > baseMaxY ? computeYAxisRange(allData).maxY : baseMaxY;
 
-	const granularity = view === "week" ? "day" : "week";
-
 	return (
 		<Card>
 			<CardHeader>
 				<CardTitle>
-					{t(($) => $.exposureTrendLineChartCard.title, { view: t(($) => $.views[view]).toLowerCase() })}
+					{t(($) => $.exposureTrendLineChartCard.title, {
+						view: t(($) => $.views[view]).toLowerCase(),
+					})}
 				</CardTitle>
 			</CardHeader>
 			<CardContent>
@@ -106,22 +83,22 @@ export function DustTrendLineChartCard({ unit }: Props) {
 					maxY={maxY}
 					series={[
 						{
-							data: maxPm1Result?.data ?? [],
+							data: pm1Data,
 							sensor,
 							sensorField: "pm1_twa",
 						},
 						{
-							data: maxPm4Result?.data ?? [],
+							data: pm4Data,
 							sensor,
 							sensorField: "pm4_twa",
 						},
 						{
-							data: maxPm25Result?.data ?? [],
+							data: pm25Data,
 							sensor,
 							sensorField: "pm25_twa",
 						},
 						{
-							data: maxPm10Result?.data ?? [],
+							data: pm10Data,
 							sensor,
 							sensorField: "pm10_twa",
 						},

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -1,10 +1,11 @@
-import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { SensorUnit } from "@/lib/sensors";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
@@ -17,6 +18,7 @@ export function DustTrendLineChartCard({ unit }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
+	const { t } = useTranslation();
 
 	const sensor = "dust";
 
@@ -91,7 +93,9 @@ export function DustTrendLineChartCard({ unit }: Props) {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Trend</CardTitle>
+				<CardTitle>
+					{t(($) => $.exposureTrendLineChartCard.title, { view: t(($) => $.views[view]).toLowerCase() })}
+				</CardTitle>
 			</CardHeader>
 			<CardContent>
 				<TrendLineChart

--- a/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/dust-trend-line-chart-card.tsx
@@ -1,15 +1,14 @@
 import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import type { SensorTypeField } from "@/lib/dto";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import type { SensorUnit } from "@/lib/sensors";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQueries } from "@tanstack/react-query";
-import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { BaseTrendLineChartCard } from "./base-trend-line-chart-card";
 import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
@@ -20,7 +19,6 @@ export function DustTrendLineChartCard({ unit }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
-	const { t } = useTranslation();
 
 	const sensor = "dust";
 
@@ -66,45 +64,36 @@ export function DustTrendLineChartCard({ unit }: Props) {
 	const maxY = maxValue > baseMaxY ? computeYAxisRange(allData).maxY : baseMaxY;
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>
-					{t(($) => $.exposureTrendLineChartCard.title, {
-						view: t(($) => $.views[view]).toLowerCase(),
-					})}
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<TrendLineChart
-					selectedDate={date}
-					granularity={granularity}
-					unit={unit}
-					minY={minY}
-					maxY={maxY}
-					series={[
-						{
-							data: pm1Data,
-							sensor,
-							sensorField: "pm1_twa",
-						},
-						{
-							data: pm4Data,
-							sensor,
-							sensorField: "pm4_twa",
-						},
-						{
-							data: pm25Data,
-							sensor,
-							sensorField: "pm25_twa",
-						},
-						{
-							data: pm10Data,
-							sensor,
-							sensorField: "pm10_twa",
-						},
-					]}
-				/>
-			</CardContent>
-		</Card>
+		<BaseTrendLineChartCard>
+			<TrendLineChart
+				selectedDate={date}
+				granularity={granularity}
+				unit={unit}
+				minY={minY}
+				maxY={maxY}
+				series={[
+					{
+						data: pm1Data,
+						sensor,
+						sensorField: "pm1_twa",
+					},
+					{
+						data: pm4Data,
+						sensor,
+						sensorField: "pm4_twa",
+					},
+					{
+						data: pm25Data,
+						sensor,
+						sensorField: "pm25_twa",
+					},
+					{
+						data: pm10Data,
+						sensor,
+						sensorField: "pm10_twa",
+					},
+				]}
+			/>
+		</BaseTrendLineChartCard>
 	);
 }

--- a/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
@@ -1,0 +1,72 @@
+import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { sensorQueryOptions } from "@/lib/api";
+import { buildSensorQuery } from "@/lib/sensor-query-utils";
+import { computeYAxisRange } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { useDate } from "../date-picker/use-date";
+import { useUser } from "../user/user-context";
+import { useView } from "../views/use-view";
+
+interface Props {
+	usePeakAggregation?: boolean;
+}
+
+export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
+	const { date } = useDate();
+	const { view } = useView();
+	const { user } = useUser();
+
+	const sensor = "noise";
+
+	const query = buildSensorQuery(sensor, view, date, {
+		usePeakAggregation,
+	});
+
+	const { data: response } = useQuery(
+		sensorQueryOptions({
+			sensor: sensor,
+			query,
+			userId: user.id,
+		}),
+	);
+
+	const data = response?.data;
+
+	const maxValue = data
+		? Math.max(...data.map((d) => (usePeakAggregation && d.peakValue ? d.peakValue : d.value)))
+		: 0;
+
+	const minY = 0;
+	let maxY = 150;
+	if (maxValue > maxY) {
+		maxY = computeYAxisRange(data ?? [], {
+			step: usePeakAggregation ? 130 : undefined,
+		}).maxY;
+	}
+
+	const granularity = view === "week" ? "day" : "week";
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Trend</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<TrendLineChart
+					selectedDate={date}
+					granularity={granularity}
+					unit="db" //TODO: Should this always use db?
+					minY={minY}
+					maxY={maxY}
+					series={[
+						{
+							data: data ?? [],
+							sensor: sensor,
+						},
+					]}
+				/>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
@@ -1,9 +1,10 @@
-import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
@@ -16,6 +17,7 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
+	const { t } = useTranslation();
 
 	const sensor = "noise";
 
@@ -50,7 +52,11 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Trend</CardTitle>
+				<CardTitle>
+					{t(($) => $.exposureTrendLineChartCard.title, {
+						view: t(($) => $.views[view]).toLowerCase(),
+					})}
+				</CardTitle>
 			</CardHeader>
 			<CardContent>
 				<TrendLineChart

--- a/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
 	usePeakAggregation?: boolean;
@@ -33,7 +34,9 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 		}),
 	);
 
-	const data = response?.data;
+	const granularity = view === "week" ? "day" : "week";
+
+	const data = granularity === "week" ? toWeeklyMax(response?.data ?? []) : response?.data;
 
 	const maxValue = data
 		? Math.max(...data.map((d) => (usePeakAggregation && d.peakValue ? d.peakValue : d.value)))
@@ -46,8 +49,6 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 			step: usePeakAggregation ? 130 : undefined,
 		}).maxY;
 	}
-
-	const granularity = view === "week" ? "day" : "week";
 
 	return (
 		<Card>

--- a/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
@@ -1,13 +1,12 @@
 import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { BaseTrendLineChartCard } from "./base-trend-line-chart-card";
 import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
@@ -18,7 +17,6 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
-	const { t } = useTranslation();
 
 	const sensor = "noise";
 
@@ -51,29 +49,20 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 	}
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>
-					{t(($) => $.exposureTrendLineChartCard.title, {
-						view: t(($) => $.views[view]).toLowerCase(),
-					})}
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<TrendLineChart
-					selectedDate={date}
-					granularity={granularity}
-					unit="db" //TODO: Should this always use db?
-					minY={minY}
-					maxY={maxY}
-					series={[
-						{
-							data: data ?? [],
-							sensor: sensor,
-						},
-					]}
-				/>
-			</CardContent>
-		</Card>
+		<BaseTrendLineChartCard>
+			<TrendLineChart
+				selectedDate={date}
+				granularity={granularity}
+				unit="db" //TODO: Should this always use db?
+				minY={minY}
+				maxY={maxY}
+				series={[
+					{
+						data: data ?? [],
+						sensor: sensor,
+					},
+				]}
+			/>
+		</BaseTrendLineChartCard>
 	);
 }

--- a/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/noise-trend-line-chart-card.tsx
@@ -11,9 +11,10 @@ import { toWeeklyMax } from "./trend-line-chart-utils";
 
 interface Props {
 	usePeakAggregation?: boolean;
+	userId?: string;
 }
 
-export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
+export function NoiseTrendLineChartCard({ usePeakAggregation, userId }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
@@ -28,7 +29,7 @@ export function NoiseTrendLineChartCard({ usePeakAggregation }: Props) {
 		sensorQueryOptions({
 			sensor: sensor,
 			query,
-			userId: user.id,
+			userId: userId ?? user.id,
 		}),
 	);
 

--- a/frontend/app/features/trend-line-chart-card/trend-line-chart-utils.ts
+++ b/frontend/app/features/trend-line-chart-card/trend-line-chart-utils.ts
@@ -1,0 +1,25 @@
+import type { SensorDto } from "@/lib/dto";
+import { startOfWeek } from "date-fns";
+
+/**
+ * Returns one datapoint for each week, with the maximum value of that week
+ */
+export function toWeeklyMax(data: Array<SensorDto>): Array<SensorDto> {
+	const maxByWeek = new Map<string, SensorDto>();
+
+	for (const item of data) {
+		const weekStart = startOfWeek(item.time, { weekStartsOn: 1 });
+		const key = weekStart.toISOString();
+
+		const existing = maxByWeek.get(key);
+
+		if (!existing || item.value > existing.value) {
+			maxByWeek.set(key, {
+				...item,
+				time: weekStart,
+			});
+		}
+	}
+
+	return Array.from(maxByWeek.values()).sort((a, b) => a.time.getTime() - b.time.getTime());
+}

--- a/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
@@ -9,7 +9,11 @@ import { useView } from "../views/use-view";
 import { BaseTrendLineChartCard } from "./base-trend-line-chart-card";
 import { toWeeklyMax } from "./trend-line-chart-utils";
 
-export function VibrationTrendLineChartCard() {
+interface Props {
+	userId?: string;
+}
+
+export function VibrationTrendLineChartCard({ userId }: Props) {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
@@ -22,7 +26,7 @@ export function VibrationTrendLineChartCard() {
 		sensorQueryOptions({
 			sensor,
 			query,
-			userId: user.id,
+			userId: userId ?? user.id,
 		}),
 	);
 

--- a/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { toWeeklyMax } from "./trend-line-chart-utils";
 
 export function VibrationTrendLineChartCard() {
 	const { date } = useDate();
@@ -27,7 +28,9 @@ export function VibrationTrendLineChartCard() {
 		}),
 	);
 
-	const data = response?.data;
+	const granularity = view === "week" ? "day" : "week";
+
+	const data = granularity === "week" ? toWeeklyMax(response?.data ?? []) : response?.data;
 
 	const maxValue = data ? Math.max(...data.map((d) => d.value)) : 0;
 
@@ -36,8 +39,6 @@ export function VibrationTrendLineChartCard() {
 	if (maxValue > maxY) {
 		maxY = computeYAxisRange(data ?? []).maxY;
 	}
-
-	const granularity = view === "week" ? "day" : "week";
 
 	return (
 		<Card>

--- a/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
@@ -1,9 +1,10 @@
-import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
@@ -12,6 +13,7 @@ export function VibrationTrendLineChartCard() {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
+	const { t } = useTranslation();
 
 	const sensor = "vibration";
 
@@ -40,7 +42,11 @@ export function VibrationTrendLineChartCard() {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Trend</CardTitle>
+				<CardTitle>
+					{t(($) => $.exposureTrendLineChartCard.title, {
+						view: t(($) => $.views[view]).toLowerCase(),
+					})}
+				</CardTitle>
 			</CardHeader>
 			<CardContent>
 				<TrendLineChart

--- a/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
@@ -1,20 +1,18 @@
 import { TrendLineChart } from "@/components/exposure-trend-line-chart/trend-line-chart";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { sensorQueryOptions } from "@/lib/api";
 import { buildSensorQuery } from "@/lib/sensor-query-utils";
 import { computeYAxisRange } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useTranslation } from "react-i18next";
 import { useDate } from "../date-picker/use-date";
 import { useUser } from "../user/user-context";
 import { useView } from "../views/use-view";
+import { BaseTrendLineChartCard } from "./base-trend-line-chart-card";
 import { toWeeklyMax } from "./trend-line-chart-utils";
 
 export function VibrationTrendLineChartCard() {
 	const { date } = useDate();
 	const { view } = useView();
 	const { user } = useUser();
-	const { t } = useTranslation();
 
 	const sensor = "vibration";
 
@@ -41,29 +39,20 @@ export function VibrationTrendLineChartCard() {
 	}
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>
-					{t(($) => $.exposureTrendLineChartCard.title, {
-						view: t(($) => $.views[view]).toLowerCase(),
-					})}
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<TrendLineChart
-					selectedDate={date}
-					granularity={granularity}
-					unit="points"
-					minY={minY}
-					maxY={maxY}
-					series={[
-						{
-							data: data ?? [],
-							sensor: sensor,
-						},
-					]}
-				/>
-			</CardContent>
-		</Card>
+		<BaseTrendLineChartCard>
+			<TrendLineChart
+				selectedDate={date}
+				granularity={granularity}
+				unit="points"
+				minY={minY}
+				maxY={maxY}
+				series={[
+					{
+						data: data ?? [],
+						sensor: sensor,
+					},
+				]}
+			/>
+		</BaseTrendLineChartCard>
 	);
 }

--- a/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
+++ b/frontend/app/features/trend-line-chart-card/vibration-trend-line-chart-card.tsx
@@ -1,0 +1,62 @@
+import { TrendLineChart } from "@/components/exposure-line-chart/trend-line-chart";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { sensorQueryOptions } from "@/lib/api";
+import { buildSensorQuery } from "@/lib/sensor-query-utils";
+import { computeYAxisRange } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { useDate } from "../date-picker/use-date";
+import { useUser } from "../user/user-context";
+import { useView } from "../views/use-view";
+
+export function VibrationTrendLineChartCard() {
+	const { date } = useDate();
+	const { view } = useView();
+	const { user } = useUser();
+
+	const sensor = "vibration";
+
+	const query = buildSensorQuery(sensor, view, date);
+
+	const { data: response } = useQuery(
+		sensorQueryOptions({
+			sensor,
+			query,
+			userId: user.id,
+		}),
+	);
+
+	const data = response?.data;
+
+	const maxValue = data ? Math.max(...data.map((d) => d.value)) : 0;
+
+	const minY = 0;
+	let maxY = 450;
+	if (maxValue > maxY) {
+		maxY = computeYAxisRange(data ?? []).maxY;
+	}
+
+	const granularity = view === "week" ? "day" : "week";
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Trend</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<TrendLineChart
+					selectedDate={date}
+					granularity={granularity}
+					unit="points"
+					minY={minY}
+					maxY={maxY}
+					series={[
+						{
+							data: data ?? [],
+							sensor: sensor,
+						},
+					]}
+				/>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -21,13 +21,23 @@
     "overview": "Overview",
     "selectPlaceholder": "Sensor",
     "dustFields": {
+      "pm1_stel": "PM1",
+      "pm25_stel": "PM2.5",
+      "pm4_stel": "PM4",
+      "pm10_stel": "PM10",
       "pm1_twa": "PM1",
       "pm25_twa": "PM2.5",
+      "pm4_twa": "PM4",
       "pm10_twa": "PM10"
     },
     "dustExposureLabels": {
+      "pm1_stel": "PM1 (STEL)",
+      "pm25_stel": "PM2.5 (STEL)",
+      "pm4_stel": "PM4 (STEL)",
+      "pm10_stel": "PM10 (STEL)",
       "pm1_twa": "PM1 (TWA)",
       "pm25_twa": "PM2.5 (TWA)",
+      "pm4_twa": "PM4 (TWA)",
       "pm10_twa": "PM10 (TWA)"
     },
     "units": {

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -323,5 +323,8 @@
     "today": "Today",
     "previous": "Previous",
     "next": "Next"
+  },
+  "exposureTrendLineChartCard": {
+    "title": "Exposure trend for {{view}}"
   }
 }

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "today": "Today",
     "total": "Total exposure",
     "notifications": "Notifications",
-    "exportAsPdf": "Export as PDF"
+    "exportAsPdf": "Export as PDF",
+    "weekNumber": "Week {{week}}"
   },
   "sensors": {
     "dust": "Dust",

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -324,5 +324,8 @@
     "today": "I dag",
     "previous": "Forrige",
     "next": "Neste"
+  },
+  "exposureTrendLineChartCard": {
+    "title": "Eksponeringstrend for {{view}}"
   }
 }

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -22,13 +22,23 @@
     "overview": "Oversikt",
     "selectPlaceholder": "Sensor",
     "dustFields": {
+      "pm1_stel": "PM1",
+      "pm25_stel": "PM2.5",
+      "pm4_stel": "PM4",
+      "pm10_stel": "PM10",
       "pm1_twa": "PM1",
       "pm25_twa": "PM2.5",
+      "pm4_twa": "PM4",
       "pm10_twa": "PM10"
     },
     "dustExposureLabels": {
+      "pm1_stel": "PM1 (STEL)",
+      "pm25_stel": "PM2.5 (STEL)",
+      "pm4_stel": "PM4 (STEL)",
+      "pm10_stel": "PM10 (STEL)",
       "pm1_twa": "PM1 (TWA)",
       "pm25_twa": "PM2.5 (TWA)",
+      "pm4_twa": "PM4 (TWA)",
       "pm10_twa": "PM10 (TWA)"
     },
     "units": {

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -12,7 +12,8 @@
     "total": "Total eksponering",
     "points": "Poeng",
     "notifications": "Notifikasjoner",
-    "exportAsPdf": "Eksporter som PDF"
+    "exportAsPdf": "Eksporter som PDF",
+    "weekNumber": "Uke {{week}}"
   },
   "sensors": {
     "dust": "Støv",

--- a/frontend/app/lib/utils.ts
+++ b/frontend/app/lib/utils.ts
@@ -214,3 +214,14 @@ export function formatSensorValue(
 
 	return value.toFixed(resolvedNumberOfUnits);
 }
+
+/**
+ * Peak data doesn't have a warning danger level, so we treat warning levels as safe
+ */
+export function normalizeDangerLevelForPeakForLineChart(dangerLevel: DangerLevel, isPeak?: boolean): DangerLevel {
+	if (isPeak && dangerLevel === "warning") {
+		return "safe";
+	}
+
+	return dangerLevel;
+}

--- a/frontend/app/routes/foreman/user-details.tsx
+++ b/frontend/app/routes/foreman/user-details.tsx
@@ -9,6 +9,9 @@ import { GaugeChart } from "@/components/ui/gauge-chart";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DateContext } from "@/features/date-picker/use-date";
 import { DayWidget } from "@/features/day-widget/day-widget";
+import { DustTrendLineChartCard } from "@/features/trend-line-chart-card/dust-trend-line-chart-card";
+import { NoiseTrendLineChartCard } from "@/features/trend-line-chart-card/noise-trend-line-chart-card";
+import { VibrationTrendLineChartCard } from "@/features/trend-line-chart-card/vibration-trend-line-chart-card";
 import { useView } from "@/features/views/use-view";
 import { WeekWidget } from "@/features/week-widget/week-widget";
 import { useExportPDF } from "@/hooks/use-export-pdf";
@@ -222,6 +225,8 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 	const minTime = setHours(selectedDate, minHour);
 	const maxTime = setHours(selectedDate, maxHour);
 
+	const showTrendLineChart = view === "month" || view === "week";
+
 	return (
 		<div className="flex max-w-4xl flex-col gap-6">
 			<Tabs value={dustField} onValueChange={(value) => setDustField(value as DustField)}>
@@ -317,6 +322,8 @@ function DustUserChart({ selectedUser, selectedDate }: { selectedUser: UserWithS
 					/>
 				}
 			</div>
+
+			{showTrendLineChart && <DustTrendLineChartCard unit={dustUnit} userId={selectedUser.id} />}
 		</div>
 	);
 }
@@ -368,52 +375,57 @@ function VibrationUserChart({ selectedUser, selectedDate }: { selectedUser: User
 	const minTime = setHours(selectedDate, minHour);
 	const maxTime = setHours(selectedDate, maxHour);
 
+	const showTrendLineChart = view === "month" || view === "week";
+
 	return (
-		<SensorChartCard
-			isLoading={isLoading}
-			isError={isError}
-			data={data}
-			selectedDate={selectedDate}
-			isSensor={true}
-		>
-			<DateScopedChart selectedDate={selectedDate}>
-				{view === "week" ? (
-					<WeekWidget
-						dayStartHour={minHour}
-						dayEndHour={maxHour}
-						data={mapOverviewDataToTimeBucketStatuses(overviewResponse?.data ?? [])}
-					/>
-				) : (
-					<div id={chartContainerId}>
-						<ExposureLineChartCard
-							minTime={minTime}
-							maxTime={maxTime}
-							chartData={downsampleSensorData(sensor, data ?? [])}
-							unit={"points"}
-							maxY={maxY}
-							minY={minY}
-							lineType="monotone"
-							sensor={sensor}
-							headerRight={
-								<ExportButton
-									title={t(($) => $.common.exportAsPdf)}
-									onClick={() =>
-										exportToPDF(
-											chartContainerId,
-											`${formatChartDate(selectedDate, i18n.language)}-${selectedUser.name}-Vibration-Exposure-Overview`,
-											`Vibration Exposure - ${selectedUser.name} - ${selectedDate.toLocaleDateString(i18n.language)}`,
-										)
-									}
-								/>
-							}
-						>
-							<ThresholdLine y={vibrationThreshold.danger} dangerLevel="danger" />
-							<ThresholdLine y={vibrationThreshold.warning} dangerLevel="warning" />
-						</ExposureLineChartCard>
-					</div>
-				)}
-			</DateScopedChart>
-		</SensorChartCard>
+		<div className="flex flex-col gap-12">
+			<SensorChartCard
+				isLoading={isLoading}
+				isError={isError}
+				data={data}
+				selectedDate={selectedDate}
+				isSensor={true}
+			>
+				<DateScopedChart selectedDate={selectedDate}>
+					{view === "week" ? (
+						<WeekWidget
+							dayStartHour={minHour}
+							dayEndHour={maxHour}
+							data={mapOverviewDataToTimeBucketStatuses(overviewResponse?.data ?? [])}
+						/>
+					) : (
+						<div id={chartContainerId}>
+							<ExposureLineChartCard
+								minTime={minTime}
+								maxTime={maxTime}
+								chartData={downsampleSensorData(sensor, data ?? [])}
+								unit={"points"}
+								maxY={maxY}
+								minY={minY}
+								lineType="monotone"
+								sensor={sensor}
+								headerRight={
+									<ExportButton
+										title={t(($) => $.common.exportAsPdf)}
+										onClick={() =>
+											exportToPDF(
+												chartContainerId,
+												`${formatChartDate(selectedDate, i18n.language)}-${selectedUser.name}-Vibration-Exposure-Overview`,
+												`Vibration Exposure - ${selectedUser.name} - ${selectedDate.toLocaleDateString(i18n.language)}`,
+											)
+										}
+									/>
+								}
+							>
+								<ThresholdLine y={vibrationThreshold.danger} dangerLevel="danger" />
+								<ThresholdLine y={vibrationThreshold.warning} dangerLevel="warning" />
+							</ExposureLineChartCard>
+						</div>
+					)}
+				</DateScopedChart>
+			</SensorChartCard>
+			{showTrendLineChart && <VibrationTrendLineChartCard userId={selectedUser.id} />}
+		</div>
 	);
 }
 
@@ -476,69 +488,74 @@ function NoiseUserChart({ selectedUser, selectedDate }: { selectedUser: UserWith
 	const minTime = setHours(selectedDate, minHour);
 	const maxTime = setHours(selectedDate, maxHour);
 
-	return (
-		<div className="flex max-w-4xl flex-col gap-4">
-			<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
-				<TabsList>
-					<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
-					<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
-				</TabsList>
-			</Tabs>
+	const showTrendLineChart = view === "month" || view === "week";
 
-			<SensorChartCard
-				isLoading={isLoading}
-				isError={isError}
-				data={data}
-				selectedDate={selectedDate}
-				isSensor={true}
-			>
-				<DateScopedChart selectedDate={selectedDate}>
-					{view === "week" ? (
-						<WeekWidget
-							dayStartHour={minHour}
-							dayEndHour={maxHour}
-							data={mapOverviewDataToTimeBucketStatuses(overviewResponse?.data ?? [])}
-						/>
-					) : (
-						<div id={chartContainerId}>
-							<ExposureLineChartCard
-								minTime={minTime}
-								maxTime={maxTime}
-								usePeakData={usePeakAggregation}
-								chartData={downsampleSensorData(sensor, data ?? [])}
-								unit="dbTwa"
-								maxY={maxY}
-								minY={minY}
-								sensor={sensor}
-								headerRight={
-									<ExportButton
-										title={t(($) => $.common.exportAsPdf)}
-										onClick={() =>
-											exportToPDF(
-												chartContainerId,
-												`${formatChartDate(selectedDate, i18n.language)}-${selectedUser.name}-Noise-Exposure-Overview`,
-												`Noise Exposure - ${selectedUser.name} - ${selectedDate.toLocaleDateString(i18n.language)}`,
-											)
-										}
-									/>
-								}
-							>
-								<ThresholdLine
-									y={
-										usePeakAggregation
-											? (noiseThreshold.peakDanger ?? noiseThreshold.danger)
-											: noiseThreshold.danger
+	return (
+		<div className="flex flex-col gap-12">
+			<div className="flex max-w-4xl flex-col gap-4">
+				<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
+					<TabsList>
+						<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
+						<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
+					</TabsList>
+				</Tabs>
+
+				<SensorChartCard
+					isLoading={isLoading}
+					isError={isError}
+					data={data}
+					selectedDate={selectedDate}
+					isSensor={true}
+				>
+					<DateScopedChart selectedDate={selectedDate}>
+						{view === "week" ? (
+							<WeekWidget
+								dayStartHour={minHour}
+								dayEndHour={maxHour}
+								data={mapOverviewDataToTimeBucketStatuses(overviewResponse?.data ?? [])}
+							/>
+						) : (
+							<div id={chartContainerId}>
+								<ExposureLineChartCard
+									minTime={minTime}
+									maxTime={maxTime}
+									usePeakData={usePeakAggregation}
+									chartData={downsampleSensorData(sensor, data ?? [])}
+									unit="dbTwa"
+									maxY={maxY}
+									minY={minY}
+									sensor={sensor}
+									headerRight={
+										<ExportButton
+											title={t(($) => $.common.exportAsPdf)}
+											onClick={() =>
+												exportToPDF(
+													chartContainerId,
+													`${formatChartDate(selectedDate, i18n.language)}-${selectedUser.name}-Noise-Exposure-Overview`,
+													`Noise Exposure - ${selectedUser.name} - ${selectedDate.toLocaleDateString(i18n.language)}`,
+												)
+											}
+										/>
 									}
-									dangerLevel="danger"
-								/>
-								{!usePeakAggregation && (
-									<ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />
-								)}
-							</ExposureLineChartCard>
-						</div>
-					)}
-				</DateScopedChart>
-			</SensorChartCard>
+								>
+									<ThresholdLine
+										y={
+											usePeakAggregation
+												? (noiseThreshold.peakDanger ?? noiseThreshold.danger)
+												: noiseThreshold.danger
+										}
+										dangerLevel="danger"
+									/>
+									{!usePeakAggregation && (
+										<ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />
+									)}
+								</ExposureLineChartCard>
+							</div>
+						)}
+					</DateScopedChart>
+				</SensorChartCard>
+			</div>
+			{showTrendLineChart && <NoiseTrendLineChartCard userId={selectedUser.id} />}
 		</div>
 	);
 }

--- a/frontend/app/routes/operator/sensors/dust.tsx
+++ b/frontend/app/routes/operator/sensors/dust.tsx
@@ -8,6 +8,7 @@ import { Card, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CalendarWidget } from "@/features/calendar-widget/calendar-widget";
 import { useDate } from "@/features/date-picker/use-date";
+import { DustTrendLineChartCard } from "@/features/trend-line-chart-card/dust-trend-line-chart-card";
 import { useUser } from "@/features/user/user-context";
 import { useView } from "@/features/views/use-view";
 import { WeekWidget } from "@/features/week-widget/week-widget";
@@ -82,82 +83,87 @@ export default function Dust() {
 	const minTime = setHours(date, minHour);
 	const maxTime = setHours(date, maxHour);
 
-	return (
-		<div className="flex flex-1 flex-col gap-4">
-			<Tabs value={dustField} onValueChange={(value) => setDustField(value as DustField)}>
-				<TabsList>
-					{dustFields.map((field) => (
-						<TabsTrigger key={field} value={field}>
-							{t(($) => $.sensors.dustFields[field])}
-						</TabsTrigger>
-					))}
-				</TabsList>
-			</Tabs>
+	const showTrendLineChart = view === "month" || view === "week";
 
-			{isLoading ? (
-				<ExposureLineChartCardSkeleton />
-			) : isError ? (
-				<Card className="flex h-full w-full items-center">
-					<p>{t(($) => $.common.error)}</p>
-				</Card>
-			) : view === "month" ? (
-				<CalendarWidget selectedDay={date} data={calendarData} />
-			) : view === "week" ? (
-				<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
-			) : !data || data.length === 0 ? (
-				<Card className="flex h-24 w-full items-center">
-					<CardTitle>
-						{date.toLocaleDateString(locale, {
-							day: "numeric",
-							month: "long",
-							year: "numeric",
-						})}
-					</CardTitle>
-					<p>{t(($) => $.common.noData)}</p>
-				</Card>
-			) : (
-				<div className="w-full">
-					<div id={chartContainerId}>
-						<ExposureLineChartCard
-							minTime={minTime}
-							maxTime={maxTime}
-							chartData={downsampleSensorData(sensor, data ?? [])}
-							unit={dustUnit}
-							maxY={maxY}
-							minY={minY}
-							sensor={sensor}
-							dustField={query.field}
-							headerRight={
-								<div className="flex items-center gap-2">
-									<Tabs value={dustUnit} onValueChange={(v) => setDustUnit(v as SensorUnit)}>
-										<TabsList>
-											<TabsTrigger value="ug">{t(($) => $.sensors.units.ug)}</TabsTrigger>
-											<TabsTrigger value="mg">{t(($) => $.sensors.units.mg)}</TabsTrigger>
-										</TabsList>
-									</Tabs>
-									<ExportButton
-										title={t(($) => $.common.exportAsPdf)}
-										onClick={() =>
-											exportToPDF(
-												chartContainerId,
-												`${date.toLocaleDateString(locale, {
-													day: "numeric",
-													month: "long",
-													year: "numeric",
-												})}-${user.name}-Dust-Exposure-Overview`,
-												`Dust Exposure - ${user.name} - ${date.toLocaleDateString(locale)}`,
-											)
-										}
-									/>
-								</div>
-							}
-						>
-							<ThresholdLine y={dustThreshold.danger} dangerLevel="danger" />
-							<ThresholdLine y={dustThreshold.warning} dangerLevel="warning" />
-						</ExposureLineChartCard>
+	return (
+		<div className="flex flex-col gap-16">
+			<div className="flex flex-1 flex-col gap-4">
+				<Tabs value={dustField} onValueChange={(value) => setDustField(value as DustField)}>
+					<TabsList>
+						{dustFields.map((field) => (
+							<TabsTrigger key={field} value={field}>
+								{t(($) => $.sensors.dustFields[field])}
+							</TabsTrigger>
+						))}
+					</TabsList>
+				</Tabs>
+
+				{isLoading ? (
+					<ExposureLineChartCardSkeleton />
+				) : isError ? (
+					<Card className="flex h-full w-full items-center">
+						<p>{t(($) => $.common.error)}</p>
+					</Card>
+				) : view === "month" ? (
+					<CalendarWidget selectedDay={date} data={calendarData} />
+				) : view === "week" ? (
+					<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
+				) : !data || data.length === 0 ? (
+					<Card className="flex h-24 w-full items-center">
+						<CardTitle>
+							{date.toLocaleDateString(locale, {
+								day: "numeric",
+								month: "long",
+								year: "numeric",
+							})}
+						</CardTitle>
+						<p>{t(($) => $.common.noData)}</p>
+					</Card>
+				) : (
+					<div className="w-full">
+						<div id={chartContainerId}>
+							<ExposureLineChartCard
+								minTime={minTime}
+								maxTime={maxTime}
+								chartData={downsampleSensorData(sensor, data ?? [])}
+								unit={dustUnit}
+								maxY={maxY}
+								minY={minY}
+								sensor={sensor}
+								dustField={query.field}
+								headerRight={
+									<div className="flex items-center gap-2">
+										<Tabs value={dustUnit} onValueChange={(v) => setDustUnit(v as SensorUnit)}>
+											<TabsList>
+												<TabsTrigger value="ug">{t(($) => $.sensors.units.ug)}</TabsTrigger>
+												<TabsTrigger value="mg">{t(($) => $.sensors.units.mg)}</TabsTrigger>
+											</TabsList>
+										</Tabs>
+										<ExportButton
+											title={t(($) => $.common.exportAsPdf)}
+											onClick={() =>
+												exportToPDF(
+													chartContainerId,
+													`${date.toLocaleDateString(locale, {
+														day: "numeric",
+														month: "long",
+														year: "numeric",
+													})}-${user.name}-Dust-Exposure-Overview`,
+													`Dust Exposure - ${user.name} - ${date.toLocaleDateString(locale)}`,
+												)
+											}
+										/>
+									</div>
+								}
+							>
+								<ThresholdLine y={dustThreshold.danger} dangerLevel="danger" />
+								<ThresholdLine y={dustThreshold.warning} dangerLevel="warning" />
+							</ExposureLineChartCard>
+						</div>
 					</div>
-				</div>
-			)}
+				)}
+			</div>
+			{showTrendLineChart && <DustTrendLineChartCard unit={dustUnit} />}
 		</div>
 	);
 }

--- a/frontend/app/routes/operator/sensors/noise.tsx
+++ b/frontend/app/routes/operator/sensors/noise.tsx
@@ -8,6 +8,7 @@ import { Card, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CalendarWidget } from "@/features/calendar-widget/calendar-widget";
 import { useDate } from "@/features/date-picker/use-date";
+import { NoiseTrendLineChartCard } from "@/features/trend-line-chart-card/noise-trend-line-chart-card";
 import { useUser } from "@/features/user/user-context";
 import { useView } from "@/features/views/use-view";
 import { WeekWidget } from "@/features/week-widget/week-widget";
@@ -87,78 +88,85 @@ export default function Noise() {
 	const minTime = setHours(date, minHour);
 	const maxTime = setHours(date, maxHour);
 
-	return (
-		<div className="flex flex-1 flex-col gap-4">
-			<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
-				<TabsList>
-					<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
-					<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
-				</TabsList>
-			</Tabs>
+	const showTrendLineChart = view === "month" || view === "week";
 
-			{isLoading ? (
-				<ExposureLineChartCardSkeleton />
-			) : isError ? (
-				<Card className="flex h-full w-full items-center">
-					<p>{t(($) => $.common.error)}</p>
-				</Card>
-			) : view === "month" ? (
-				<CalendarWidget selectedDay={date} selectedAggregation={aggregation} data={calendarData} />
-			) : view === "week" ? (
-				<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
-			) : !data || data.length === 0 ? (
-				<Card className="flex h-24 w-full items-center">
-					<CardTitle>
-						{date.toLocaleDateString(i18n.language, {
-							day: "numeric",
-							month: "long",
-							year: "numeric",
-						})}
-					</CardTitle>
-					<p>{t(($) => $.common.noData)}</p>
-				</Card>
-			) : (
-				<div className="w-full">
-					<div id={chartContainerId}>
-						<ExposureLineChartCard
-							minTime={minTime}
-							maxTime={maxTime}
-							chartData={downsampleSensorData(sensor, data ?? [])}
-							unit="dbTwa"
-							maxY={maxY}
-							minY={minY}
-							sensor={sensor}
-							headerRight={
-								<ExportButton
-									title={t(($) => $.common.exportAsPdf)}
-									onClick={() =>
-										exportToPDF(
-											chartContainerId,
-											`${date.toLocaleDateString(i18n.language, {
-												day: "numeric",
-												month: "long",
-												year: "numeric",
-											})}-${user.name}-Noise-Exposure-Overview`,
-											`Noise Exposure - ${user.name} - ${date.toLocaleDateString(i18n.language)}`,
-										)
-									}
-								/>
-							}
-						>
-							<ThresholdLine
-								y={
-									usePeakAggregation
-										? // biome-ignore lint/style/noNonNullAssertion: If usePeakAggregation is true and peakDangerLevel is null, there is a bug somewhere else
-											noiseThreshold.peakDanger!
-										: noiseThreshold.danger
+	return (
+		<div className="flex flex-col gap-16">
+			<div className="flex flex-1 flex-col gap-4">
+				<Tabs value={aggregation} onValueChange={(value) => setAggregation(value as Aggregation)}>
+					<TabsList>
+						<TabsTrigger value="average">{t(($) => $.measurement.average)}</TabsTrigger>
+						<TabsTrigger value="peak">{t(($) => $.measurement.peak)}</TabsTrigger>
+					</TabsList>
+				</Tabs>
+
+				{isLoading ? (
+					<ExposureLineChartCardSkeleton />
+				) : isError ? (
+					<Card className="flex h-full w-full items-center">
+						<p>{t(($) => $.common.error)}</p>
+					</Card>
+				) : view === "month" ? (
+					<CalendarWidget selectedDay={date} selectedAggregation={aggregation} data={calendarData} />
+				) : view === "week" ? (
+					<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
+				) : !data || data.length === 0 ? (
+					<Card className="flex h-24 w-full items-center">
+						<CardTitle>
+							{date.toLocaleDateString(i18n.language, {
+								day: "numeric",
+								month: "long",
+								year: "numeric",
+							})}
+						</CardTitle>
+						<p>{t(($) => $.common.noData)}</p>
+					</Card>
+				) : (
+					<div className="w-full">
+						<div id={chartContainerId}>
+							<ExposureLineChartCard
+								minTime={minTime}
+								maxTime={maxTime}
+								chartData={downsampleSensorData(sensor, data ?? [])}
+								unit="dbTwa"
+								maxY={maxY}
+								minY={minY}
+								sensor={sensor}
+								headerRight={
+									<ExportButton
+										title={t(($) => $.common.exportAsPdf)}
+										onClick={() =>
+											exportToPDF(
+												chartContainerId,
+												`${date.toLocaleDateString(i18n.language, {
+													day: "numeric",
+													month: "long",
+													year: "numeric",
+												})}-${user.name}-Noise-Exposure-Overview`,
+												`Noise Exposure - ${user.name} - ${date.toLocaleDateString(i18n.language)}`,
+											)
+										}
+									/>
 								}
-								dangerLevel="danger"
-							/>
-							{!usePeakAggregation && <ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />}
-						</ExposureLineChartCard>
+							>
+								<ThresholdLine
+									y={
+										usePeakAggregation
+											? // biome-ignore lint/style/noNonNullAssertion: If usePeakAggregation is true and peakDangerLevel is null, there is a bug somewhere else
+												noiseThreshold.peakDanger!
+											: noiseThreshold.danger
+									}
+									dangerLevel="danger"
+								/>
+								{!usePeakAggregation && (
+									<ThresholdLine y={noiseThreshold.warning} dangerLevel="warning" />
+								)}
+							</ExposureLineChartCard>
+						</div>
 					</div>
-				</div>
-			)}
+				)}
+			</div>
+			{showTrendLineChart && <NoiseTrendLineChartCard usePeakAggregation={usePeakAggregation} />}
 		</div>
 	);
 }

--- a/frontend/app/routes/operator/sensors/vibration.tsx
+++ b/frontend/app/routes/operator/sensors/vibration.tsx
@@ -7,6 +7,7 @@ import { ThresholdLine } from "@/components/exposure-line-chart/threshold-line";
 import { Card, CardTitle } from "@/components/ui/card";
 import { CalendarWidget } from "@/features/calendar-widget/calendar-widget";
 import { useDate } from "@/features/date-picker/use-date";
+import { VibrationTrendLineChartCard } from "@/features/trend-line-chart-card/vibration-trend-line-chart-card";
 import { useUser } from "@/features/user/user-context";
 import { parseAsView } from "@/features/views/utils";
 import { WeekWidget } from "@/features/week-widget/week-widget";
@@ -70,66 +71,71 @@ export default function Vibration() {
 	const minTime = setHours(date, minHour);
 	const maxTime = setHours(date, maxHour);
 
+	const showTrendLineChart = view === "month" || view === "week";
+
 	return (
-		<div className="flex h-full w-full flex-col-reverse gap-4 md:flex-row">
-			<div className="flex flex-1 flex-col gap-4">
-				{isLoading ? (
-					<ExposureLineChartCardSkeleton />
-				) : isError ? (
-					<Card className="flex h-full w-full items-center">
-						<p>{t(($) => $.common.error)}</p>
-					</Card>
-				) : view === "month" ? (
-					<CalendarWidget selectedDay={date} data={calendarData} />
-				) : view === "week" ? (
-					<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
-				) : !data || data.length === 0 ? (
-					<Card className="flex h-full w-full items-center">
-						<CardTitle>
-							{date.toLocaleDateString(i18n.language, {
-								day: "numeric",
-								month: "long",
-								year: "numeric",
-							})}
-						</CardTitle>
-						<p>{t(($) => $.common.noData)}</p>
-					</Card>
-				) : (
-					<div className="w-full">
-						<div id={chartContainerId}>
-							<ExposureLineChartCard
-								minTime={minTime}
-								maxTime={maxTime}
-								chartData={downsampleSensorData(sensor, data ?? [])}
-								unit={"points"}
-								maxY={maxY}
-								minY={minY}
-								lineType="monotone"
-								sensor={sensor}
-								headerRight={
-									<ExportButton
-										title={t(($) => $.common.exportAsPdf)}
-										onClick={() =>
-											exportToPDF(
-												chartContainerId,
-												`${date.toLocaleDateString(i18n.language, {
-													day: "numeric",
-													month: "long",
-													year: "numeric",
-												})}-${user.name}-Vibration-Exposure-Overview`,
-												`Vibration Exposure - ${user.name} - ${date.toLocaleDateString(i18n.language)}`,
-											)
-										}
-									/>
-								}
-							>
-								<ThresholdLine y={vibrationThreshold.danger} dangerLevel="danger" />
-								<ThresholdLine y={vibrationThreshold.warning} dangerLevel="warning" />
-							</ExposureLineChartCard>
+		<div className="flex flex-col gap-16">
+			<div className="flex h-full w-full flex-col-reverse gap-4 md:flex-row">
+				<div className="flex flex-1 flex-col gap-4">
+					{isLoading ? (
+						<ExposureLineChartCardSkeleton />
+					) : isError ? (
+						<Card className="flex h-full w-full items-center">
+							<p>{t(($) => $.common.error)}</p>
+						</Card>
+					) : view === "month" ? (
+						<CalendarWidget selectedDay={date} data={calendarData} />
+					) : view === "week" ? (
+						<WeekWidget dayStartHour={minHour} dayEndHour={maxHour} data={calendarData} />
+					) : !data || data.length === 0 ? (
+						<Card className="flex h-full w-full items-center">
+							<CardTitle>
+								{date.toLocaleDateString(i18n.language, {
+									day: "numeric",
+									month: "long",
+									year: "numeric",
+								})}
+							</CardTitle>
+							<p>{t(($) => $.common.noData)}</p>
+						</Card>
+					) : (
+						<div className="w-full">
+							<div id={chartContainerId}>
+								<ExposureLineChartCard
+									minTime={minTime}
+									maxTime={maxTime}
+									chartData={downsampleSensorData(sensor, data ?? [])}
+									unit={"points"}
+									maxY={maxY}
+									minY={minY}
+									lineType="monotone"
+									sensor={sensor}
+									headerRight={
+										<ExportButton
+											title={t(($) => $.common.exportAsPdf)}
+											onClick={() =>
+												exportToPDF(
+													chartContainerId,
+													`${date.toLocaleDateString(i18n.language, {
+														day: "numeric",
+														month: "long",
+														year: "numeric",
+													})}-${user.name}-Vibration-Exposure-Overview`,
+													`Vibration Exposure - ${user.name} - ${date.toLocaleDateString(i18n.language)}`,
+												)
+											}
+										/>
+									}
+								>
+									<ThresholdLine y={vibrationThreshold.danger} dangerLevel="danger" />
+									<ThresholdLine y={vibrationThreshold.warning} dangerLevel="warning" />
+								</ExposureLineChartCard>
+							</div>
 						</div>
-					</div>
-				)}
+					)}
+				</div>
 			</div>
+			{showTrendLineChart && <VibrationTrendLineChartCard />}
 		</div>
 	);
 }


### PR DESCRIPTION
Only shown in week and month view in operator and foreman user details page. 

<img width="1378" height="1216" alt="image" src="https://github.com/user-attachments/assets/4ace778a-5643-4f47-93e6-0b6453926bea" />

In the dust view, there's one line per dust field. The lines just overlap in this example because our sample dust data is awful
<img width="1332" height="871" alt="image" src="https://github.com/user-attachments/assets/250746b0-d29e-4267-b6e6-1a01037da3ac" />

