### PR TITLE
fix(frontend): use consistent query keys across refetches

### DIFF
--- a/frontend/app/components/notes-card.tsx
+++ b/frontend/app/components/notes-card.tsx
@@ -4,6 +4,7 @@ import { useView } from "@/features/views/use-view";
 import { useFormatDate } from "@/hooks/use-format-date.js";
 import { TIMEZONE } from "@/i18n/locale";
 import { createNote, deleteNote, notesQueryOptions, updateNote } from "@/lib/api";
+import { buildNotesQueryKeyPrefix } from "@/lib/query-key-builder";
 import { cn } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { isSameDay } from "date-fns";
@@ -37,7 +38,9 @@ export const NotesCard = ({ forceInteractiveMode = false }: NotesCardProps) => {
 	const { mutate: mutateCreateNote } = useMutation({
 		mutationFn: createNote,
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: ["notes"] });
+			queryClient.invalidateQueries({
+				queryKey: buildNotesQueryKeyPrefix(user.id),
+			});
 			refetch();
 		},
 	});
@@ -45,7 +48,9 @@ export const NotesCard = ({ forceInteractiveMode = false }: NotesCardProps) => {
 	const { mutate: mutateUpdateNote } = useMutation({
 		mutationFn: updateNote,
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: ["notes"] });
+			queryClient.invalidateQueries({
+				queryKey: buildNotesQueryKeyPrefix(user.id),
+			});
 			refetch();
 		},
 	});
@@ -53,7 +58,9 @@ export const NotesCard = ({ forceInteractiveMode = false }: NotesCardProps) => {
 	const { mutate: mutateDeleteNote } = useMutation({
 		mutationFn: deleteNote,
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: ["notes"] });
+			queryClient.invalidateQueries({
+				queryKey: buildNotesQueryKeyPrefix(user.id),
+			});
 			refetch();
 		},
 	});

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -113,6 +113,7 @@ export function sensorOverviewQueryOptions({
 		enabled,
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
 		placeholderData: keepPreviousData,
+		refetchIntervalInBackground: true,
 	});
 }
 
@@ -144,6 +145,7 @@ export function sensorQueryOptions({
 		enabled,
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
 		placeholderData: keepPreviousData,
+		refetchIntervalInBackground: true,
 	});
 }
 
@@ -242,6 +244,7 @@ export const fetchSubordinatesQueryOptions = (userId: string, startTime?: TZDate
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
 		placeholderData: keepPreviousData,
+		refetchIntervalInBackground: true,
 	});
 };
 
@@ -326,4 +329,5 @@ export const fetchThresholdSummaryQueryOptions = (managerUserId: string, startTi
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
 		placeholderData: keepPreviousData,
+		refetchIntervalInBackground: true,
 	});

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -1,6 +1,6 @@
 import type { Sensor } from "@/features/sensor-picker/sensors";
 import type { TZDate } from "@date-fns/tz";
-import { queryOptions, useMutation, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions, useMutation, useQueryClient } from "@tanstack/react-query";
 import { minutesToMilliseconds } from "date-fns";
 import { fetchWithUserId } from "./api-client";
 import {
@@ -17,6 +17,15 @@ import {
 	UserSchema,
 	UserWithStatusSchema,
 } from "./dto";
+import {
+	buildNotesQueryKey,
+	buildSensorOverviewQueryKey,
+	buildSensorQueryKey,
+	buildSubordinatesQueryKey,
+	buildSubordinatesQueryPrefix,
+	buildThresholdSummaryQueryKey,
+	type SensorQueryKind,
+} from "./query-key-builder";
 import { getStartEnd } from "./sensor-query-utils";
 import type { View } from "./views";
 
@@ -40,6 +49,7 @@ export function usersQueryOptions() {
 		queryFn: () => fetchAllUsers(),
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});
 }
 
@@ -82,17 +92,27 @@ export function sensorOverviewQueryOptions({
 	query,
 	userId,
 	enabled,
+	queryKind,
+	windowMinutes,
 }: {
 	query: SensorOverviewRequestDto;
 	userId?: string;
 	enabled?: boolean;
+	queryKind?: SensorQueryKind;
+	windowMinutes?: number;
 }) {
 	return queryOptions({
-		queryKey: [query, userId],
+		queryKey: buildSensorOverviewQueryKey({
+			userId,
+			query,
+			queryKind,
+			windowMinutes,
+		}),
 		queryFn: () => fetchSensorOverviewData(query, userId),
 		staleTime: minutesToMilliseconds(10),
 		enabled,
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});
 }
 
@@ -101,18 +121,29 @@ export function sensorQueryOptions({
 	query,
 	userId,
 	enabled,
+	queryKind,
+	windowMinutes,
 }: {
 	sensor: Sensor;
 	query: SensorDataRequestDto;
 	userId?: string;
 	enabled?: boolean;
+	queryKind?: SensorQueryKind;
+	windowMinutes?: number;
 }) {
 	return queryOptions({
-		queryKey: [sensor, query, userId],
+		queryKey: buildSensorQueryKey({
+			sensor,
+			userId,
+			query,
+			queryKind,
+			windowMinutes,
+		}),
 		queryFn: () => fetchSensorData(sensor, query, userId),
 		staleTime: minutesToMilliseconds(10),
 		enabled,
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});
 }
 
@@ -134,10 +165,11 @@ export function notesQueryOptions({ view, selectedDay, userId }: { view: View; s
 	const query = getStartEnd(view, selectedDay);
 
 	return queryOptions({
-		queryKey: ["notes", query, userId],
+		queryKey: buildNotesQueryKey(userId, query.startTime, query.endTime),
 		queryFn: () => fetchNoteData(query, userId),
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});
 }
 
@@ -196,7 +228,7 @@ export const fetchSubordinatesQueryOptions = (userId: string, startTime?: TZDate
 	}
 
 	return queryOptions({
-		queryKey: ["user.subordinates", userId, startTime, endTime],
+		queryKey: buildSubordinatesQueryKey(userId, startTime, endTime),
 		queryFn: async () => {
 			const response = await fetchWithUserId(`users/${userId}/subordinates?${params.toString()}`);
 
@@ -209,6 +241,7 @@ export const fetchSubordinatesQueryOptions = (userId: string, startTime?: TZDate
 		},
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});
 };
 
@@ -232,7 +265,7 @@ export const useRemoveSubordinatesMutation = (parentUserId: string) => {
 		mutationFn: (subordinateIds: Array<string>) => removeSubordinates(parentUserId, subordinateIds),
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({
-				queryKey: fetchSubordinatesQueryOptions(parentUserId).queryKey,
+				queryKey: buildSubordinatesQueryPrefix(parentUserId),
 			});
 		},
 	});
@@ -258,7 +291,7 @@ export const useAddSubordinatesMutation = (parentUserId: string) => {
 		mutationFn: (subordinateIds: Array<string>) => addSubordinates(parentUserId, subordinateIds),
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({
-				queryKey: fetchSubordinatesQueryOptions(parentUserId).queryKey,
+				queryKey: buildSubordinatesQueryPrefix(parentUserId),
 			});
 		},
 	});
@@ -266,7 +299,7 @@ export const useAddSubordinatesMutation = (parentUserId: string) => {
 
 export const fetchThresholdSummaryQueryOptions = (managerUserId: string, startTime?: TZDate, endTime?: TZDate) =>
 	queryOptions({
-		queryKey: ["user.subordinates.threshold-summary", managerUserId, startTime, endTime],
+		queryKey: buildThresholdSummaryQueryKey(managerUserId, startTime, endTime),
 		queryFn: async () => {
 			const params = new URLSearchParams();
 			if (startTime) {
@@ -292,4 +325,5 @@ export const fetchThresholdSummaryQueryOptions = (managerUserId: string, startTi
 		},
 		staleTime: minutesToMilliseconds(10),
 		refetchInterval: DEFAULT_REFETCH_INTERVAL,
+		placeholderData: keepPreviousData,
 	});

--- a/frontend/app/lib/query-key-builder.ts
+++ b/frontend/app/lib/query-key-builder.ts
@@ -1,0 +1,100 @@
+import type { TZDate } from "@date-fns/tz";
+import { startOfDay } from "date-fns";
+import type { SensorDataRequestDto, SensorOverviewRequestDto } from "./dto";
+import { type Sensor, sensors } from "./sensors";
+
+/**
+ * For queries that fetches data for exact time-ranges and not just whole days, `windowed` should be used.
+ * If not, startTime and endTime will be normalized to the start of their respective days to ensure cache key consistency.
+ */
+export type SensorQueryKind = "default" | "windowed";
+
+function buildSensorQueryCachePart({
+	query,
+	queryKind,
+	windowMinutes,
+}: {
+	query?: SensorDataRequestDto;
+	queryKind?: SensorQueryKind;
+	windowMinutes?: number;
+}) {
+	if (!query) {
+		return ["disabled"];
+	}
+
+	const base = [query.field ?? null, query.granularity, query.function];
+
+	if (queryKind === "windowed") {
+		return [...base, "windowed", windowMinutes ?? null];
+	}
+
+	return [...base, startOfDay(query.startTime).getTime(), startOfDay(query.endTime).getTime()];
+}
+
+export function buildSensorQueryKey({
+	sensor,
+	userId,
+	query,
+	queryKind,
+	windowMinutes,
+}: {
+	sensor: Sensor;
+	userId?: string;
+	query?: SensorDataRequestDto;
+	queryKind?: SensorQueryKind;
+	windowMinutes?: number;
+}) {
+	return ["sensor", userId ?? null, sensor, ...buildSensorQueryCachePart({ query, queryKind, windowMinutes })];
+}
+
+export function buildSensorOverviewQueryKey({
+	query,
+	userId,
+	queryKind,
+	windowMinutes,
+}: {
+	query: SensorOverviewRequestDto;
+	userId?: string;
+	queryKind?: SensorQueryKind;
+	windowMinutes?: number;
+}) {
+	const sensorKeys = sensors.map((sensor) => [
+		sensor,
+		...buildSensorQueryCachePart({
+			query: query[sensor],
+			queryKind,
+			windowMinutes,
+		}),
+	]);
+
+	return ["sensor-overview", userId ?? null, ...sensorKeys.flat()];
+}
+
+export function buildSubordinatesQueryKey(userId: string, startTime?: TZDate, endTime?: TZDate) {
+	const start = startTime ? startOfDay(startTime).getTime() : null;
+	const end = endTime ? startOfDay(endTime).getTime() : null;
+
+	return ["user.subordinates", userId, start, end];
+}
+
+export function buildNotesQueryKey(userId: string, startTime: TZDate, endTime: TZDate) {
+	const start = startOfDay(startTime).getTime();
+	const end = startOfDay(endTime).getTime();
+
+	return ["notes", userId, start, end];
+}
+
+export function buildThresholdSummaryQueryKey(userId: string, startTime?: TZDate, endTime?: TZDate) {
+	const start = startTime ? startOfDay(startTime).getTime() : null;
+	const end = endTime ? startOfDay(endTime).getTime() : null;
+
+	return ["user.subordinates.threshold-summary", userId, start, end];
+}
+
+export function buildNotesQueryKeyPrefix(userId: string) {
+	return ["notes", userId];
+}
+
+export function buildSubordinatesQueryPrefix(userId: string) {
+	return ["user.subordinates", userId];
+}

--- a/frontend/app/routes/operator/live.tsx
+++ b/frontend/app/routes/operator/live.tsx
@@ -42,9 +42,11 @@ export default function OperatorLiveView() {
 
 	const targetUserId = selectedUserId ?? user.id;
 
+	const timeRangeInMinutes = TIME_RANGE_MINUTES[timeRange];
+
 	const startOfCurrentMinute = startOfMinute(now());
 	const end = startOfCurrentMinute;
-	const start = addMinutes(startOfCurrentMinute, -TIME_RANGE_MINUTES[timeRange]);
+	const start = addMinutes(startOfCurrentMinute, -timeRangeInMinutes);
 
 	const [dustTwa1Result, dustTwa25Result, dustTwa10Result, noiseResult, vibrationResult] = useQueries({
 		queries: [
@@ -58,6 +60,8 @@ export default function OperatorLiveView() {
 					endTime: end,
 				}),
 				userId: targetUserId,
+				queryKind: "windowed",
+				windowMinutes: timeRangeInMinutes,
 			}),
 			sensorQueryOptions({
 				sensor: "dust",
@@ -69,6 +73,8 @@ export default function OperatorLiveView() {
 					endTime: end,
 				}),
 				userId: targetUserId,
+				queryKind: "windowed",
+				windowMinutes: timeRangeInMinutes,
 			}),
 			sensorQueryOptions({
 				sensor: "dust",
@@ -80,6 +86,8 @@ export default function OperatorLiveView() {
 					endTime: end,
 				}),
 				userId: targetUserId,
+				queryKind: "windowed",
+				windowMinutes: timeRangeInMinutes,
 			}),
 			sensorQueryOptions({
 				sensor: "noise",
@@ -89,6 +97,8 @@ export default function OperatorLiveView() {
 					endTime: end,
 				}),
 				userId: targetUserId,
+				queryKind: "windowed",
+				windowMinutes: timeRangeInMinutes,
 			}),
 			sensorQueryOptions({
 				sensor: "vibration",
@@ -98,6 +108,8 @@ export default function OperatorLiveView() {
 					endTime: end,
 				}),
 				userId: targetUserId,
+				queryKind: "windowed",
+				windowMinutes: timeRangeInMinutes,
 			}),
 		],
 	});


### PR DESCRIPTION
This fixes the issue where graphs lost data while queries refetched