### PR TITLE
fix(frontend): make `ExposureDot` ignore pointer events

### DIFF
--- a/frontend/app/components/users-status-pie-chart.tsx
+++ b/frontend/app/components/users-status-pie-chart.tsx
@@ -75,7 +75,7 @@ const CustomLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name
 	const dangerLevel = dangerLevelParseResult.success ? dangerLevelParseResult.data : null;
 
 	return (
-		<g transform={`translate(${x},${y})`} className="relative">
+		<g transform={`translate(${x},${y})`} className="pointer-events-none relative">
 			<foreignObject x={-sizePx / 2} y={-sizePx / 2} width={sizePx} height={sizePx}>
 				<DangerLevelDots dangerLevel={dangerLevel} />
 			</foreignObject>

--- a/frontend/app/features/calendar-widget/calendar-widget.tsx
+++ b/frontend/app/features/calendar-widget/calendar-widget.tsx
@@ -150,7 +150,10 @@ function CustomDay({ data, day, className, handleDayClick, ...buttonProps }: Cus
 					{day.date.getDate()}
 				</span>
 			</span>
-			<DangerLevelDots dangerLevel={dangerLevel ?? null} className="absolute right-2 bottom-2" />
+			<DangerLevelDots
+				dangerLevel={dangerLevel ?? null}
+				className="pointer-events-none absolute right-2 bottom-2"
+			/>
 		</button>
 	);
 }


### PR DESCRIPTION
<img width="528" height="622" alt="image" src="https://github.com/user-attachments/assets/f670a9be-1c7b-49a3-933b-28099708f969" />

<img width="620" height="651" alt="image" src="https://github.com/user-attachments/assets/36f287de-cf76-4a87-9482-17c22f867338" />

Made the button tranparent to the cursor, so the tooltips or hover effects happen even when hovering over the dots.