### PR TITLE
feat(frontend): update security regulation designs

### DIFF
--- a/frontend/app/components/notes-card.tsx
+++ b/frontend/app/components/notes-card.tsx
@@ -20,7 +20,7 @@ function NotesShell({ title, children }: PropsWithChildren<{ title: string }>) {
 	return (
 		<Card muted={true} variant="labeled" className="max-h-96 w-full overflow-y-auto">
 			<CardLabelHeader>
-				<NotebookPenIcon className="size-3.5 text-muted-foreground" />
+				<NotebookPenIcon className="size-4 text-muted-foreground" />
 				<h2 className="font-medium text-muted-foreground text-xs uppercase tracking-wider">{title}</h2>
 			</CardLabelHeader>
 			{children}

--- a/frontend/app/features/popups/profile-popup.tsx
+++ b/frontend/app/features/popups/profile-popup.tsx
@@ -1,11 +1,13 @@
 import type { User } from "@/lib/dto.js";
+import { getSecurityRegulations } from "@/lib/security-regulations.js";
 import { userRoleToString } from "@/lib/utils.js";
+import { BriefcaseBusiness, MapPin, User as UserIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { BasePopup } from "./base-popup";
 
 interface ProfilePopupProps {
 	user: User;
-	avatarSrc: string;
+	avatarSrc?: string;
 	open: boolean;
 	onClose: () => void;
 	users?: Array<User>;
@@ -16,57 +18,61 @@ interface ProfilePopupProps {
 export function ProfilePopup({ user, open, onClose, avatarSrc, children }: ProfilePopupProps) {
 	const { t } = useTranslation();
 	const title = t(($) => $.profile.title);
-
-	const tempListOfRegulations = ["Safety boots", "Helmet", "Protective mask"];
+	const regulations = getSecurityRegulations(t);
 
 	return (
 		<BasePopup title={title} open={open} relevantDate={null} onClose={onClose}>
 			{children}
 
-			<div className="flex flex-col gap-3 text-sm md:px-0 md:pb-1">
-				<div className="flex flex-row items-center gap-4">
+			<div className="flex flex-col gap-6 pt-2 text-sm">
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+					{avatarSrc ? (
+						<img
+							src={avatarSrc}
+							height={100}
+							width={100}
+							alt={user.name}
+							className="size-20 rounded-full object-cover"
+						/>
+					) : (
+						<div className="flex size-20 items-center justify-center rounded-full bg-primary">
+							<UserIcon className="size-9 text-primary-foreground" />
+						</div>
+					)}
+
 					<div>
-						{avatarSrc ? (
-							<img
-								src={avatarSrc}
-								height={100}
-								width={100}
-								alt={user.name}
-								className="h-full w-full rounded-full object-cover"
-							/>
-						) : (
-							<div className="h-20 w-20 rounded-full bg-blue-900"></div>
-						)}
-					</div>
-					<div className="flex w-full flex-col">
-						<div className="flex flex-row gap-3">
-							<p className="label text-muted-foreground">{t(($) => $.profile.name)}</p>
-							<h2>{user.name}</h2>
-						</div>
-						<div className="flex flex-row gap-3">
+						<h2 className="font-semibold text-xl">{user.name}</h2>
+
+						<div className="mt-2 grid grid-cols-[1rem_auto_minmax(0,1fr)] items-start gap-x-3 gap-y-1">
+							<MapPin className="mt-0.5 size-4 text-muted-foreground" />
 							<p className="label text-muted-foreground">{t(($) => $.profile.location)}</p>
-							<h3>{user.location.site}</h3>
-						</div>
-						<div className="flex flex-row gap-3">
+							<p className="min-w-0 truncate font-medium">{user.location.site}</p>
+
+							<BriefcaseBusiness className="mt-0.5 size-4 text-muted-foreground" />
 							<p className="label text-muted-foreground">{t(($) => $.profile.jobTitle)}</p>
-							<h3>{userRoleToString(user.role, t)}</h3>
+							<p className="min-w-0 font-medium">{userRoleToString(user.role, t)}</p>
 						</div>
 					</div>
 				</div>
+
 				<div className="flex flex-col gap-2">
 					<h4 className="text-muted-foreground">{t(($) => $.profile.currentSecurityRegulations)}</h4>
-					<div className="w-full rounded-lg bg-card-highlight p-2">
-						<ul className="ml-5 list-disc">
-							{tempListOfRegulations.map((reg) => (
-								<li key={reg}>{reg}</li>
+					<div className="w-full rounded-xl bg-card-highlight p-3">
+						<ul className="space-y-2">
+							{regulations.map(({ icon: Icon, label }) => (
+								<li key={label} className="flex items-center gap-3">
+									<Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+									<span>{label}</span>
+								</li>
 							))}
 						</ul>
 					</div>
 				</div>
+
 				<div className="flex flex-col gap-2">
-					<p className="label text-muted-foreground">{t(($) => $.profile.jobDescription)}</p>
-					<div className="w-full rounded-lg bg-card-highlight p-2">
-						<p>{user.jobDescription}</p>
+					<h4 className="text-muted-foreground">{t(($) => $.profile.jobDescription)}</h4>
+					<div className="w-full rounded-xl bg-card-highlight p-3">
+						<p>{user.jobDescription ?? "-"}</p>
 					</div>
 				</div>
 			</div>

--- a/frontend/app/features/security-regulations-card/security-regulations-card.tsx
+++ b/frontend/app/features/security-regulations-card/security-regulations-card.tsx
@@ -1,25 +1,16 @@
 import { Card, CardContent, CardLabelHeader } from "@/components/ui/card";
-import { Footprints, HardHat, ShieldCheckIcon } from "lucide-react";
+import { getSecurityRegulations } from "@/lib/security-regulations.js";
+import { ShieldCheckIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 export const SecurityRegulationsCard = () => {
 	const { t } = useTranslation();
-
-	const regulations = [
-		{
-			icon: Footprints,
-			label: t(($) => $.securityRegulationsCard.safetyBoots),
-		},
-		{
-			icon: HardHat,
-			label: t(($) => $.securityRegulationsCard.helmet),
-		},
-	];
+	const regulations = getSecurityRegulations(t);
 
 	return (
 		<Card muted={true} variant="labeled" className="max-h-96 w-full overflow-y-auto">
 			<CardLabelHeader>
-				<ShieldCheckIcon size="1rem" />
+				<ShieldCheckIcon className="size-4 shrink-0" />
 				<h2 className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
 					{t(($) => $.securityRegulationsCard.title)}
 				</h2>

--- a/frontend/app/features/sidebar/limit-explanation.tsx
+++ b/frontend/app/features/sidebar/limit-explanation.tsx
@@ -6,20 +6,20 @@ export function LimitExplanation() {
 	const { t } = useTranslation();
 
 	return (
-		<Card muted={true}>
+		<Card muted={true} className="px-3 py-2">
 			<CardContent>
 				<div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1.5">
 					<div className="flex size-5 scale-75 items-center justify-center rounded-full border border-danger-border bg-danger-subtle">
 						<DangerLevelDots dangerLevel="danger" size="sm" />
 					</div>
-					<p className="font-medium text-xs">{t(($) => $.limitExplanation.limitValue.label)}</p>
+					<p className="font-medium text-sm">{t(($) => $.limitExplanation.limitValue.label)}</p>
 					<p className="col-start-2 text-xs">{t(($) => $.limitExplanation.limitValue.description)}</p>
 				</div>
 				<div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
 					<div className="flex size-5 scale-75 items-center justify-center rounded-full border border-warning-border bg-warning-subtle">
 						<DangerLevelDots dangerLevel="warning" size="sm" />
 					</div>
-					<p className="font-medium text-xs">{t(($) => $.limitExplanation.actionValue.label)}</p>
+					<p className="font-medium text-sm">{t(($) => $.limitExplanation.actionValue.label)}</p>
 					<p className="col-start-2 text-xs">{t(($) => $.limitExplanation.actionValue.description)}</p>
 				</div>
 			</CardContent>

--- a/frontend/app/features/sidebar/team-summary.tsx
+++ b/frontend/app/features/sidebar/team-summary.tsx
@@ -11,7 +11,7 @@ export const TeamSummary = ({ subordinateCount }: { subordinateCount: number }) 
 	return (
 		<Card muted={true} variant="labeled">
 			<CardLabelHeader>
-				<ShieldUserIcon size="1rem" />
+				<ShieldUserIcon className="size-4" />
 				<h2 className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
 					{t(($) => $.sidebar.yourTeam)}
 				</h2>
@@ -19,13 +19,13 @@ export const TeamSummary = ({ subordinateCount }: { subordinateCount: number }) 
 
 			<CardContent>
 				<div className="flex items-center gap-2">
-					<MapPinIcon className="size-3.5" />
-					<p className="text-xs">{createLocationName(user.location)}</p>
+					<MapPinIcon className="size-4 shrink-0" />
+					<p className="text-sm">{createLocationName(user.location)}</p>
 				</div>
 
 				<div className="flex items-center gap-2">
-					<UsersIcon className="size-3.5" />
-					<p className="text-xs">
+					<UsersIcon className="size-4" />
+					<p className="text-sm">
 						{t(($) => $.foremanDashboard.team.membersCount, {
 							count: subordinateCount,
 						})}

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -127,7 +127,7 @@
     },
     "list": {
       "title": "Your notes",
-      "noNotes": "No notes for this {{view}}. Select a day to add notes."
+      "noNotes": "No notes for this {{view}}. View a day to add notes."
     }
   },
   "table": {

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -127,7 +127,7 @@
     },
     "list": {
       "title": "Your notes",
-      "noNotes": "No notes for this {{view}}. View a day to add notes."
+      "noNotes": "No notes for this {{view}}. Select a day to add notes."
     }
   },
   "table": {
@@ -249,7 +249,7 @@
       "week": "Week"
     },
     "userStatusChart": {
-      "xAxisLabel": "Percentage of exposure limit",
+      "xAxisLabel": "% of exposure limit",
       "noData": "No exposure data available for any operators"
     },
     "siteMap": {
@@ -293,7 +293,7 @@
       "viewWeek": "Week {{week}}",
       "viewMonth": "Month",
       "dateDay": "{{date}}",
-      "dateRange": "{{startDate}} to {{endDate}}"
+      "dateRange": "{{startDate}} - {{endDate}}"
     }
   },
   "register": {
@@ -310,7 +310,8 @@
   "securityRegulationsCard": {
     "title": "Current safety regulations",
     "safetyBoots": "Safety boots",
-    "helmet": "Helmet"
+    "helmet": "Helmet",
+    "protectiveMask": "Protective mask"
   },
   "share": {
     "hygienist": {

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -124,7 +124,7 @@
     },
     "list": {
       "title": "Dine notater",
-      "noNotes": "Ingen notater for denne {{view}}. Velg en dag for å legge til notater."
+      "noNotes": "Ingen notater for denne {{view}}. Se en dag for å legge til notater."
     }
   },
   "table": {

--- a/frontend/app/i18n/locales/no.json
+++ b/frontend/app/i18n/locales/no.json
@@ -124,7 +124,7 @@
     },
     "list": {
       "title": "Dine notater",
-      "noNotes": "Ingen notater for denne {{view}}. Se en dag for å legge til notater."
+      "noNotes": "Ingen notater for denne {{view}}. Velg en dag for å legge til notater."
     }
   },
   "table": {
@@ -246,7 +246,7 @@
       "week": "Uke"
     },
     "userStatusChart": {
-      "xAxisLabel": "Prosent av faregrense",
+      "xAxisLabel": "% av faregrense",
       "noData": "Ingen eksponeringsdata tilgjengelig for operatører"
     },
     "siteMap": {
@@ -290,7 +290,7 @@
       "viewWeek": "Uke {{week}}",
       "viewMonth": "Måned",
       "dateDay": "{{date}}",
-      "dateRange": "{{startDate}} til {{endDate}}"
+      "dateRange": "{{startDate}} - {{endDate}}"
     }
   },
   "register": {
@@ -307,7 +307,8 @@
   "securityRegulationsCard": {
     "title": "Gjeldene sikkerhetsreguleringer",
     "safetyBoots": "Sikkerhetsstøvler",
-    "helmet": "Hjelm"
+    "helmet": "Hjelm",
+    "protectiveMask": "Beskyttelsesmaske"
   },
   "share": {
     "hygienist": {

--- a/frontend/app/lib/security-regulations.ts
+++ b/frontend/app/lib/security-regulations.ts
@@ -1,0 +1,24 @@
+import type { TranslateFn } from "@/i18n/config.js";
+import { Footprints, HardHat, type LucideIcon, ShieldPlus } from "lucide-react";
+
+export interface SecurityRegulation {
+	icon: LucideIcon;
+	label: string;
+}
+
+export function getSecurityRegulations(t: TranslateFn): Array<SecurityRegulation> {
+	return [
+		{
+			icon: Footprints,
+			label: t(($) => $.securityRegulationsCard.safetyBoots),
+		},
+		{
+			icon: HardHat,
+			label: t(($) => $.securityRegulationsCard.helmet),
+		},
+		{
+			icon: ShieldPlus,
+			label: t(($) => $.securityRegulationsCard.protectiveMask),
+		},
+	];
+}


### PR DESCRIPTION
- Centralized security regulations in a single file, to reuse in profile popup and siedebar card
<img width="548" height="444" alt="image" src="https://github.com/user-attachments/assets/86fe404c-44da-462c-8b97-21bb1dfbfe97" />
<img width="312" height="202" alt="image" src="https://github.com/user-attachments/assets/0ea950a3-52a3-415c-b821-69f1f77ac764" />
