### PR TITLE
fix(frontend): show chart tooltip value once

### DIFF
--- a/frontend/app/components/exposure-line-chart/exposure-tooltip.tsx
+++ b/frontend/app/components/exposure-line-chart/exposure-tooltip.tsx
@@ -12,6 +12,7 @@ export function ExposureTooltip({ unit }: { unit: ExposureUnit }) {
 	return (
 		<ChartTooltip
 			cursor={false}
+			payloadUniqBy={true}
 			content={
 				<ChartTooltipContent
 					labelFormatter={(_label, payload) => {

--- a/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
+++ b/frontend/app/components/exposure-trend-line-chart/exposure-trend-tooltip.tsx
@@ -16,6 +16,7 @@ export function ExposureTrendTooltip({
 	return (
 		<ChartTooltip
 			cursor={false}
+			payloadUniqBy={true}
 			content={({ active, payload, label }) => {
 				if (!(active && payload?.length)) {
 					return null;


### PR DESCRIPTION
- bug caused by payload to tooltip containing values from Line and Area chart elements.